### PR TITLE
Add a currentFrame null check.

### DIFF
--- a/unity/Assets/Scripts/Game/Entity/EntityRender.cs
+++ b/unity/Assets/Scripts/Game/Entity/EntityRender.cs
@@ -88,7 +88,7 @@ public class EntityRender : MonoBehaviour
         {
             while (m_consumedDt >= m_globalFrameDelay)
             {
-                if (m_currentFrame.m_nextFrame != null)
+                if (m_currentFrame != null && m_currentFrame.m_nextFrame != null)
                 {
                     int newIndex = m_currentFrame.m_nextFrame.m_frameIndex;
                     ChangeFrame(newIndex);


### PR DESCRIPTION
I ran into this when I was trying to nullify currentFrame for blinking purposes.  Tho I found it was better in the long run to keep currentFrame normal, and just conditionally nullify the UV coordinates instead.