### PR TITLE
Gameover screen and respawn system

### DIFF
--- a/unity/Assets/Scenes/ui.unity
+++ b/unity/Assets/Scenes/ui.unity
@@ -554,6 +554,7 @@ RectTransform:
   - {fileID: 1040750003}
   - {fileID: 2015762257}
   - {fileID: 1683125766}
+  - {fileID: 1601679114}
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -962,6 +963,137 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 22495608, guid: 088809aa19a1a1946a35a38a673a7f20,
     type: 2}
   m_PrefabInternal: {fileID: 1064489217}
+--- !u!1 &1601679113
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1601679114}
+  - component: {fileID: 1601679120}
+  - component: {fileID: 1601679119}
+  - component: {fileID: 1601679118}
+  - component: {fileID: 1601679117}
+  - component: {fileID: 1601679116}
+  - component: {fileID: 1601679115}
+  m_Layer: 5
+  m_Name: txt_DeadMessage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1601679114
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1601679113}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.0000045, y: 1.0000045, z: 1.0000045}
+  m_Children: []
+  m_Father: {fileID: 581289731}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -398.99994, y: 300}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!225 &1601679115
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1601679113}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 0
+  m_BlocksRaycasts: 0
+  m_IgnoreParentGroups: 0
+--- !u!114 &1601679116
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1601679113}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1741964061, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 1
+  m_VerticalFit: 1
+--- !u!114 &1601679117
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1601679113}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1573420865, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 0, g: 0, b: 0, a: 0.5}
+  m_EffectDistance: {x: 2, y: -1}
+  m_UseGraphicAlpha: 1
+--- !u!114 &1601679118
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1601679113}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -900027084, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 0.1981132, g: 0.11681203, b: 0.13275343, a: 0.5}
+  m_EffectDistance: {x: 1, y: -1}
+  m_UseGraphicAlpha: 1
+--- !u!114 &1601679119
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1601679113}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f5f67c52d1564df4a8936ccd202a3bd8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.5660378, g: 0.19860426, b: 0.08276967, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 90
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 9
+    m_MaxSize: 90
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 0
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 1
+    m_LineSpacing: 1
+  m_Text: You are dead
+--- !u!222 &1601679120
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1601679113}
+  m_CullTransparentMesh: 0
 --- !u!1 &1683125765
 GameObject:
   m_ObjectHideFlags: 0
@@ -1066,6 +1198,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_txtDynamicPrefab: {fileID: 157756, guid: cddd87594efeb5d4a84f0b4ad0f32b2b, type: 2}
   m_mouseTileInfo: {fileID: 0}
+  m_gameOverMessage: {fileID: 0}
 --- !u!4 &1842195848
 Transform:
   m_ObjectHideFlags: 0

--- a/unity/Assets/Scripts/Game/Entity/Enemy.cs
+++ b/unity/Assets/Scripts/Game/Entity/Enemy.cs
@@ -83,4 +83,19 @@ public class Enemy : Entity
         dynamicText.ParentToWorld(anchor);
         dynamicText.SimpleMovement(new Vector2(0f, 16f), 1f);
     }
+
+    protected override void OnEntityDestroy()
+    {
+        EnemyInfo enemyInfo = EnemiesInfo.GetInfoFromName(Name);
+
+        if (enemyInfo != null)
+        {
+            foreach (EItem item in enemyInfo.RandomLoot())
+            {
+                SpawnManager.Instance.SpawnLoot(item, transform.position);
+            }
+        }
+
+        base.OnEntityDestroy();
+    }
 }

--- a/unity/Assets/Scripts/Game/Entity/Enemy.cs
+++ b/unity/Assets/Scripts/Game/Entity/Enemy.cs
@@ -63,9 +63,27 @@ public class Enemy : Entity
             {
                 // give XP to main player
                 RewardWithXP();
-                RequestDestroy();
+
+                // OnKilled mean the enemy was killed as part of the gameplay, this is different from calling
+                // RequestDestroy which just means we want the enemy go to go away and disapear
+                OnKilled();
             }
         }
+    }
+
+    private void OnKilled()
+    {
+        EnemyInfo enemyInfo = EnemiesInfo.GetInfoFromName(Name);
+
+        if (enemyInfo != null)
+        {
+            foreach (EItem item in enemyInfo.RandomLoot())
+            {
+                SpawnManager.Instance.SpawnLoot(item, transform.position);
+            }
+        }
+
+        RequestDestroy();
     }
 
     private void RewardWithXP()
@@ -86,15 +104,7 @@ public class Enemy : Entity
 
     protected override void OnEntityDestroy()
     {
-        EnemyInfo enemyInfo = EnemiesInfo.GetInfoFromName(Name);
 
-        if (enemyInfo != null)
-        {
-            foreach (EItem item in enemyInfo.RandomLoot())
-            {
-                SpawnManager.Instance.SpawnLoot(item, transform.position);
-            }
-        }
 
         base.OnEntityDestroy();
     }

--- a/unity/Assets/Scripts/Game/Entity/Entity.cs
+++ b/unity/Assets/Scripts/Game/Entity/Entity.cs
@@ -102,7 +102,6 @@ public class Entity : MonoBehaviour
     protected virtual void OnEntityDestroy()
     {
         CollisionManager.Instance.OnDestroy(this);
-
         UnityEngine.Object.Destroy(gameObject);
         EntityManager.Instance.Unregister(this);
     }

--- a/unity/Assets/Scripts/Game/Entity/ItemInstance.cs
+++ b/unity/Assets/Scripts/Game/Entity/ItemInstance.cs
@@ -18,11 +18,11 @@ public class ItemInstance : Entity
     public override void OnTouch(Entity other)
     {
         base.OnTouch(other);
+    }
 
-        if (other is Player)
-        {
-            RequestDestroy();    
-        }
+    public void PickedUp(Entity source)
+    {
+        RequestDestroy();
     }
 
     public void SetType(EItem itemType)

--- a/unity/Assets/Scripts/Game/Entity/Slime.cs
+++ b/unity/Assets/Scripts/Game/Entity/Slime.cs
@@ -100,16 +100,6 @@ public class Slime : Enemy
     // when it is destroyed, we may not want to, since there could be other reasons (level ended, some cutscene removed all enemies, etc.)
     protected override void OnEntityDestroy()
     {
-        EnemyInfo enemyInfo = EnemiesInfo.GetInfoFromName(Name);
-
-        if (enemyInfo != null)
-        {
-            foreach (EItem item in enemyInfo.RandomLoot())
-            {
-                SpawnManager.Instance.SpawnLoot(item, transform.position);
-            }
-        }
-
         base.OnEntityDestroy();
     }
 

--- a/unity/Assets/Scripts/Game/Managers/EntityManager.cs
+++ b/unity/Assets/Scripts/Game/Managers/EntityManager.cs
@@ -77,6 +77,14 @@ public class EntityManager : MonoSingleton<EntityManager>
     {
         // TODO: This doesn't work, I need to actually destroy the GameObject as well
         // To be continued
+        foreach (var entity in m_entities)
+        {
+            if (entity is T)
+            {
+                entity.RequestDestroy();
+            }
+        }
+
         m_entities.RemoveAll(entity => entity is T);
     }
 

--- a/unity/Assets/Scripts/Game/Managers/EntityManager.cs
+++ b/unity/Assets/Scripts/Game/Managers/EntityManager.cs
@@ -73,6 +73,13 @@ public class EntityManager : MonoSingleton<EntityManager>
         return count;
     }
 
+    public void RemoveAll<T>()
+    {
+        // TODO: This doesn't work, I need to actually destroy the GameObject as well
+        // To be continued
+        m_entities.RemoveAll(entity => entity is T);
+    }
+
     public IEnumerable<Entity> Entities
     {
         get { return m_entities.AsReadOnly(); }

--- a/unity/Assets/Scripts/Game/Managers/GameManager.cs
+++ b/unity/Assets/Scripts/Game/Managers/GameManager.cs
@@ -76,7 +76,7 @@ public class GameManager : MonoSingleton<GameManager>
 
     public void OnMainPlayerSpawn()
     {
-        m_fsm.SwitchState<GameManagerState_Playing>();
+        m_fsm.SwitchState<GameManagerState_Init>();
     }
 
     public void OnMainPlayerDead()

--- a/unity/Assets/Scripts/Game/Managers/GameManager.cs
+++ b/unity/Assets/Scripts/Game/Managers/GameManager.cs
@@ -74,6 +74,16 @@ public class GameManager : MonoSingleton<GameManager>
         SceneManager.LoadScene("ui", LoadSceneMode.Additive);
     }
 
+    public void OnMainPlayerSpawn()
+    {
+        m_fsm.SwitchState<GameManagerState_Playing>();
+    }
+
+    public void OnMainPlayerDead()
+    {
+        m_fsm.SwitchState<GameManagerState_Dead>();
+    }
+
     void SpawnChunkAt(int x, int y)
     {
         SpawnChunkAt(new Vector2(x, y));

--- a/unity/Assets/Scripts/Game/Managers/GameManager_FSM/GameManagerState_Dead.cs
+++ b/unity/Assets/Scripts/Game/Managers/GameManager_FSM/GameManagerState_Dead.cs
@@ -8,6 +8,7 @@ public class GameManagerState_Dead : State
     public override void Constructor()
     {
         base.Constructor();
+        UIManager.Instance.DisplayGameOverMessage(new Vector2(Screen.width * 0.5f, Screen.height * 0.5f), "You are dead!");
     }
 
     public override void Destructor()

--- a/unity/Assets/Scripts/Game/Managers/GameManager_FSM/GameManagerState_Init.cs
+++ b/unity/Assets/Scripts/Game/Managers/GameManager_FSM/GameManagerState_Init.cs
@@ -16,6 +16,8 @@ public class GameManagerState_Init : State
 
         // remove all entities on the screen
         EntityManager.Instance.RemoveAll<Enemy>();
+        EntityManager.Instance.RemoveAll<ItemInstance>();
+
         SwitchState<GameManagerState_Playing>();
     }
 

--- a/unity/Assets/Scripts/Game/Managers/GameManager_FSM/GameManagerState_Init.cs
+++ b/unity/Assets/Scripts/Game/Managers/GameManager_FSM/GameManagerState_Init.cs
@@ -12,6 +12,10 @@ public class GameManagerState_Init : State
     {
         base.Constructor();
 
+        UIManager.Instance.HideGameOverMessage();
+
+        // remove all entities on the screen
+        EntityManager.Instance.RemoveAll<Enemy>();
         SwitchState<GameManagerState_Playing>();
     }
 

--- a/unity/Assets/Scripts/Game/Managers/GameManager_FSM/GameManagerState_Playing.cs
+++ b/unity/Assets/Scripts/Game/Managers/GameManager_FSM/GameManagerState_Playing.cs
@@ -8,6 +8,7 @@ public class GameManagerState_Playing : State
     public override void Constructor()
     {
         AudioManager.Instance.PlayMusic(E_Music.WorldMap);
+        UIManager.Instance.HideGameOverMessage();
 
         base.Constructor();
     }

--- a/unity/Assets/Scripts/Game/Managers/GameManager_FSM/GameManagerState_Playing.cs
+++ b/unity/Assets/Scripts/Game/Managers/GameManager_FSM/GameManagerState_Playing.cs
@@ -8,7 +8,6 @@ public class GameManagerState_Playing : State
     public override void Constructor()
     {
         AudioManager.Instance.PlayMusic(E_Music.WorldMap);
-        UIManager.Instance.HideGameOverMessage();
 
         base.Constructor();
     }

--- a/unity/Assets/Scripts/Game/Managers/SpawnManager.cs
+++ b/unity/Assets/Scripts/Game/Managers/SpawnManager.cs
@@ -156,9 +156,15 @@ public class SpawnManager : MonoSingleton<SpawnManager>
     protected override void OnInit()
     {
         base.OnInit();
+        Reset();
 
+    }
+
+    public void Reset()
+    {
         m_nextSpawn = m_initialSpawnTime;
     }
+    
 
     protected override void OnUpdate()
     {

--- a/unity/Assets/Scripts/Game/Managers/SpawnManager.cs
+++ b/unity/Assets/Scripts/Game/Managers/SpawnManager.cs
@@ -163,8 +163,10 @@ public class SpawnManager : MonoSingleton<SpawnManager>
     public void Reset()
     {
         m_nextSpawn = m_initialSpawnTime;
+        m_numEnemiesKilled = 0;
+        m_spawnTime = 0.0f;
+        m_nextSpawn = 0.0f;
     }
-    
 
     protected override void OnUpdate()
     {

--- a/unity/Assets/Scripts/Game/Managers/UIManager.cs
+++ b/unity/Assets/Scripts/Game/Managers/UIManager.cs
@@ -98,6 +98,7 @@ public class UIManager : MonoSingleton<UIManager>
     private Text m_txtLevel;
 
     public Text m_mouseTileInfo;
+    public Text m_gameOverMessage;
 
     private GameObject m_canvas;
 
@@ -127,8 +128,10 @@ public class UIManager : MonoSingleton<UIManager>
             SetupEvents(m_inventorySlot[0]);
         }
 
+        // TODO - Automate all of this using reflection
         m_healthText = GameObject.Find("Canvas/txt_Health").GetComponent<Text>();
         m_mouseTileInfo = GameObject.Find("Canvas/txt_MouseCursorHover").GetComponent<Text>();
+        m_gameOverMessage = GameObject.Find("Canvas/txt_DeadMessage").GetComponent<Text>();
         m_xpSlider = GameObject.Find("Canvas/sld_XP").GetComponent<Slider>();
         m_txtLevel = GameObject.Find("Canvas/txt_Level").GetComponent<Text>();
     }
@@ -229,6 +232,19 @@ public class UIManager : MonoSingleton<UIManager>
     {
         m_mouseTileInfo.transform.position = screenPos;
         m_mouseTileInfo.text = text;
+    }
+
+    public void DisplayGameOverMessage(Vector2 screenPos, string text)
+    {
+        // Currently hard-coded to the gameover message, but should be changed to a dynamic display system for any messages
+        m_gameOverMessage.transform.position = screenPos;
+        m_gameOverMessage.text = text;
+        m_gameOverMessage.enabled = true;
+    }
+
+    public void HideGameOverMessage()
+    {
+        m_gameOverMessage.enabled = false;
     }
 
     private void UpdateHealth()

--- a/unity/Assets/Scripts/Game/Player/Player.cs
+++ b/unity/Assets/Scripts/Game/Player/Player.cs
@@ -139,6 +139,11 @@ public class Player : Entity
     {
         base.OnTouch(other);
 
+        if (m_fsm.IsInState<PlayerState_Dead>())
+        {
+            return;
+        }
+
         ItemInstance ii = other as ItemInstance;
         if (ii != null)
         {
@@ -152,6 +157,8 @@ public class Player : Entity
             {
                 Inventory.Carry(ii.Item);
             }
+
+            ii.PickedUp(this);
         }
     }
 
@@ -159,6 +166,11 @@ public class Player : Entity
     protected override void OnUpdate () 
     {
         base.OnUpdate();
+
+        if (m_fsm.IsInState<PlayerState_Dead>())
+        {
+            return;
+        }
 
         if (HasAction)
         {
@@ -229,16 +241,31 @@ public class Player : Entity
 
     public bool CanReceiveDamage()
     {
+        if (m_fsm.IsInState<PlayerState_Dead>())
+        {
+            return false;
+        }
+
         return HealthComponent.CanReceiveDamage();
     }
 
     public void ReceiveDamage(int damage)
     {
+        if (m_fsm.IsInState<PlayerState_Dead>())
+        {
+            return;
+        }
+
         HealthComponent.ReceiveDamage(damage);
     }
 
     public void ReceiveHeal(int heal)
     {
+        if (m_fsm.IsInState<PlayerState_Dead>())
+        {
+            return;
+        }
+
         HealthComponent.ReceiveHeal(heal);
     }
 

--- a/unity/Assets/Scripts/Game/Player/PlayerState_Dead.cs
+++ b/unity/Assets/Scripts/Game/Player/PlayerState_Dead.cs
@@ -31,6 +31,7 @@ public class PlayerState_Dead : State
         if (m_playerDeathTime <= 0f)
         {
             SwitchState<PlayerState_Spawn>();
+            GameManager.Instance.OnMainPlayerSpawn();
         }
     }
 }

--- a/unity/Assets/Scripts/Game/Player/PlayerState_Live.cs
+++ b/unity/Assets/Scripts/Game/Player/PlayerState_Live.cs
@@ -29,6 +29,7 @@ public class PlayerState_Live : EntityState_Live
         if (m_player.HealthComponent.Health <= 0)
         {
             SwitchState<PlayerState_Dead>();
+            GameManager.Instance.OnMainPlayerDead();
             return;
         }
 


### PR DESCRIPTION
- Stops the character from attacking when you're dead
- Stops the character from collecting items
- Display a game over message
- Remove all enemies and  items of the screen when respawning
- Separate Entity destruction from being killed (so that they don't all gives items on respawn)
- Changed item logic to be active instead of passive: "It is the Player that acts on the Item, not the Item that is aware that a player can pick it up". This will scale better.