### PR TITLE
Add missing meta file for TouchComponent

### DIFF
--- a/unity/Assets/Scripts/Game/Player/TouchComponent.cs.meta
+++ b/unity/Assets/Scripts/Game/Player/TouchComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8760181f6312f9345b8310f18eb22cfb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Fixes broken attack mechanic for fresh clones.

I manually discovered the correct GUID by looking for an unreferenced script GUID in the SwordAttack prefab.