### PR TITLE
[Appveyor] enable unity metadata checks

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,28 +19,44 @@ skip_branch_with_pr: true
 skip_tags: true
 shallow_clone: true
 
+# Build worker image (VM template)
+image:
+  - Visual Studio 2017
+#  - Ubuntu1804
 
-# scripts that run after cloning repository
-# note that 'cmd:' scripts run on Windows nodes and that 'sh:' scripts run on linux nodes
-# scripts that start with hyphen (-) run on both, but there's very few commands that work
-# on both shells (pretty much just cd/echo, and perhaps some cross-platform executables such
-# as git).  The good news is that AppVeryor Windows images have MSYS2 installed by default,
+# shell/script execution steps  (init / before_build / after_build)
+#   * 'cmd:' scripts run only on Windows nodes
+#   * 'sh:'  scripts run on only linux nodes
+#   * scripts that start with hyphen (-) run on both, but there's very few commands that work
+#     on both shells (pretty much just cd/echo, and perhaps some cross-platform executables such
+#     as git).
+# The good news is that AppVeryor Windows images have MSYS2 installed by default,
 # which means we can use bash scripts for everything and then just provide a .bat file
 # trampoline that invokes our bash scripts under MSYS2.  So easy!  --jstine
 #
 # Note also, env vars 'CI_WINDOWS' and 'CI_LINUX' will be set true/false accordingly.
-# (apparently both vars actually set for both images so you must explicitly check for 'true'
-#  vs the usual pattern of checking if a var is non-empty)
-install:
-  cmd: echo ajek appveyor test v2
+# (apparently both vars actually set for both images so you must explicitly check for 
+#  'true' vs the usual pattern of checking if a var is non-empty)
 
-# Build worker image (VM template)
-image: Visual Studio 2017
-#image: Ubuntu1804
+# scripts that are called at very beginning, before repo cloning
+init:
+
+# scripts that run after cloning repository
+install:
+  cmd: .\ci-shell\msys-sh.cmd ./unity/BuildCI/find_missing_meta.sh ./unity
+
+before_build:
+
+after_build:
 
 build:
   parallel: true                  # enable MSBuild parallel builds
   project: rpgcraft-ajek.sln
+
+# matrix 'fast-finish' allows us to configure an early-exit if an error occurs.  If Debug
+# fails then Release won't be built.
+matrix:
+  fast_finish: true
 
 # Platform / Configuration stuff
 #   Platform is explicitly specified for possible addition of console or mobile platforms...

--- a/ci-shell/README.msys-sh.md
+++ b/ci-shell/README.msys-sh.md
@@ -1,0 +1,43 @@
+
+# msys-sh.cmd
+
+A script which invokes MSYS2 shell directly, not relying on PATH.
+MSYS2 is expected to be installed at `c:\msys64`
+
+## All the Details
+MSYS2 is a variant of CoreUtils/BASH which comes pre-installed on Appveyor windows slave images.
+It supports a package manager called pacman, which can be used to install various bits of the
+build-essential toolchain-- autoconf, automake, makefile, etc.
+
+This script is intended to be invoked directly from CI scripts only, such as Jenkinsfile or
+Appveyor.yml.  These slave build environments are controlled environments where we can safely
+assume something like MSYS2 being installed to `c:\msys64`.
+
+## Caveats
+
+ * Caution! Do not install GIT to msys2.  Build slaves will already have Git for Windos installed,
+   and MSYS2 GIT has problems.
+
+ * Take note that unexpected behavior may occur if the build scripts invoke CMD batch scripts
+   which in turn invoke Git for Windows BASH scripts.  This typically manifests as a shared DLL
+   error but in rare cases may throw other errors.
+
+## Shared DLL Error in Detail
+
+Shared DLL errors may occur if forcibly invoking BASH from Git for Windows from an MSYS2 subshell,
+or vice versa.  In normal operation of shell scripts this does not occur, because the parent shell
+invocation will add it's personal BASH instance to the PATH.  Therefore any subsequent invocation
+of `/bin/bash/` will always run one which matches the shell.
+
+The problem occurs when a CMD Batch (`.bat`) file runs a shell script.  Normally a batch file
+written to be runnable by an end user makes the assumption that BASH is not in the path, and it
+will instead try to find BASH installed by Git for Windows and run that directly.  This causes the
+error.
+
+The fix is to try to run BASH from PATH first, and then fall back on Git for Windows location
+detection only if the PATH is not set up.  If any batch file scripts are invoked which do not
+check the PATH for BASH before falling back on Git for Windows then these must be fixed directly.
+
+A shell-invocation script called `run-sh.cmd` has been provided separately which is ideal for use
+when it is necessary to invoke an MSYS2 script from cmd batch. It does a robust check of PATH, Git
+for Windows, and MSYS2 installs.

--- a/ci-shell/msys-sh.cmd
+++ b/ci-shell/msys-sh.cmd
@@ -1,0 +1,21 @@
+@echo off
+
+:: invokes MSYS2 shell directly, not relying on PATH.  This allows the env PATH to preference the Git for Windows
+:: instance of Bash/CoreUtils (which typically integrate better with Windows and may also be expected behavior by other
+:: build jobs).  MSYS2 is only needed for executing autoconf and makefile things.
+
+SETLOCAL ENABLEDELAYEDEXPANSION
+
+set CHERE_INVOKING=1
+set MSYSTEM=MINGW64
+set MSYS2_PATH_TYPE=inherit
+
+:: SHLVL is used by bash to decide if it should clear the screen after logout, which fails with an error on
+:: jenkins since there is no terminal bound to the shell. This works around it while retaining support for
+:: nested shell calls.
+
+IF not defined SHLVL set SHLVL=0
+set /a SHLVL+=1
+c:\msys64\usr\bin\bash.exe --login %*
+
+ENDLOCAL

--- a/tools/run-sh.cmd
+++ b/tools/run-sh.cmd
@@ -1,0 +1,64 @@
+@echo off
+SETLOCAL ENABLEDELAYEDEXPANSION
+
+:: Caveats:
+::   * bash.exe in the PATH is often "bogus" -- a few apps, chocolately installers in particular, install stripped-down
+::     non-functional versions of bash.exe into the PATH just so they can glob files (making them equivalent to malware imo)
+::
+::   * No way to know where MSYS2 is installed, so impose a requirement that it be c:\msys64\
+::
+::   * GIT Bash usually sets up an sh_auto_file association that allows sh files to be run directly.  But sometimes it's
+::     missing from developers' installs, or has been incorrectly re-assigned to load sh scripts into text files.
+
+:: favor git-bash ahead of MSYS2 bash as it generally integrates better with Windows.
+where git 2>NUL 1>NUL
+if %errorlevel% == 0 (
+    FOR /F "tokens=* USEBACKQ" %%F IN (`where git`) DO (
+        SET git_path=%%F
+    )
+    
+    if defined git_path (
+        call :dirname result "!git_path!"
+        set _bash_path=!result!\..\bin
+    )
+)
+
+:: falback on MSYS2 bash at the fixed location...
+if not defined _bash_path (
+    if EXIST c:\msys64\usr\bin\bash.exe (
+        set _bash_path=c:\msys64\usr\bin
+    )
+)
+
+if not defined _bash_path (
+    >&2 echo error: GIT bash was not found in the PATH.
+    >&2 echo Please install GIT bash and ensure GIT is added to the PATH.
+    exit /b 1
+)
+
+:: MSYS2 doesn't integrate with cmd shell the same way git-bash does.  It needs some env setup:
+
+if not defined git_path (
+    set CHERE_INVOKING=1
+    set MSYSTEM=MINGW64
+    set MSYS2_PATH_TYPE=inherit
+)
+
+:: avoid environment pollution in subshell
+set "git_path="
+
+:: SHLVL is used by bash to decide if it should clear the screen after logout, which fails with an error on
+:: jenkins since there is no terminal bound to the shell. This works around it while retaining support for
+:: nested shell calls.
+
+IF not defined SHLVL set SHLVL=0
+set /a SHLVL+=1
+"%_bash_path%\bash.exe" --login %*
+ENDLOCAL
+exit /b %errorlevel%
+
+:dirname <resultVar> <pathVar>
+(
+    set "%~1=%~dp2"
+    exit /b
+)

--- a/unity/BuildCI/find_missing_meta.sh
+++ b/unity/BuildCI/find_missing_meta.sh
@@ -8,7 +8,10 @@ if [[ ! -d "$assets_dir" ]]; then
 	>&2 echo "Please run this script from your unity project dir, or specify the dir"
 	>&2 echo "on the command line.  Ex:"
 	>&2 echo "   $ find_missing_meta.sh /path/to/UnityProject"
+	exit 1
 fi
+
+echo "Verifying unity metadata-to-assets references..."
 
 # search for any files in the assets dir which don't have associated .meta files.
 # done by listing all files, and stripping .meta from .meta files.  Any item in the list


### PR DESCRIPTION
Building and verifying aspects of unity is a whole other ballgame that will require either a separate CI (`TravisCI` maybe?) or AWS-managed build slaves (doable with Appveyor).

But for now the important part is to just help make sure unity isn't missing anything important.  We care less that things are running _*correctly*_ in general, and more that they're running in a consistent and expected manner for all devs.