### PR TITLE
get rid of heavyweight 'feature-laden' logging facility

### DIFF
--- a/CraftEngine/ajek-framework/h/x-ScopedMalloc.h
+++ b/CraftEngine/ajek-framework/h/x-ScopedMalloc.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include "x-stdlib.h"
+#include "x-stdalloc.h"
 #include "x-assertion.h"
 
 // --------------------------------------------------------------------------------------

--- a/CraftEngine/ajek-framework/h/x-stdalloc.h
+++ b/CraftEngine/ajek-framework/h/x-stdalloc.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "x-types.h"
+
+// ======================================================================================
+//  xCustomAllocator  (interface)
+// ======================================================================================
+class xCustomAllocator {
+public:
+    virtual void*       alloc       (size_t size)               =0;
+    virtual void*       realloc     (void* ptr, size_t size)    =0;
+    virtual void        free        (void* ptr)                 =0;
+};
+
+class xDefaultCustomAllocator : public xCustomAllocator {
+public:
+    void*       alloc       (size_t size)               override;
+    void*       realloc     (void* ptr, size_t size)    override;
+    void        free        (void* ptr)                 override;
+};
+
+extern xDefaultCustomAllocator  g_DefaultCustomAllocator;
+
+extern void     xMalloc_Check       ();
+extern void*    xMalloc             (size_t sz);
+extern void*    xCalloc             (size_t numItems, size_t sz);
+extern void*    xRealloc            (void* srcptr, size_t sz);
+extern void     xFree               (void *ptr);
+extern void*    xMalloc_Aligned     (size_t sz, u32 align);
+extern void*    xRealloc_Aligned    (void* srcptr, size_t sz, u32 align);
+extern void     xFree_Aligned       (void* ptr);
+extern void     xMalloc_Report      ();
+extern void     xMalloc_ReportDelta ();
+
+#define placement_new(T)        new (xMalloc(sizeof(T))) T
+
+// Performs cleanup of existing object pointer (if non-null) and creates a new object in its place.
+// Memory is allocated if the provided pointer is null.
+template< typename T >
+__xi T* xMallocNew(T* &ptr)
+{
+    if (ptr) {
+        ptr->~T();
+    }
+    else {
+        ptr = (T*)xMalloc(sizeof(*ptr));
+    }
+    return new (ptr) T();
+}
+
+// Memory is allocated if the provided pointer is null.  if pointer is non-null, then no action is taken.
+template< typename T >
+__xi T* xMallocT(T* &ptr)
+{
+    static_assert(!std::has_virtual_destructor<T>::value, "Non-trivial type has meaningful destructor.  Use xMallocNew<T> instead.");
+    //static_assert(!std::is_trivially_copyable<T>::value, "Non-trivial type has meaningful destructor.  Use xMallocNew<T> instead.")
+    return ptr ? ptr : xMalloc(sizeof(*ptr));
+}

--- a/CraftEngine/ajek-framework/h/x-stdfile.h
+++ b/CraftEngine/ajek-framework/h/x-stdfile.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include "x-types.h"
+#include "x-stdalloc.h"
+
+#include <cstdio>
+
+// ======================================================================================
+//  xBaseStream (abstract class)
+// ======================================================================================
+class xBaseStream
+{
+    NONCOPYABLE_OBJECT( xBaseStream );
+
+protected:
+    union {
+        // We cheat her a bit -- m_fd strictly speaking should be -1 for an empty descriptor.
+        // The API manually sets -1 to zero (0) within OpenFile() to allow !nullptr checks
+        // against m_fp to satisfy either underlying file system.  This is ok because posix
+        // fd==0 is reserved as stdin anyway, and will never be returned from open(). --jstine
+
+        FILE*       m_fp;               // non-NULL implies data is sourced from file
+        int         m_fd;
+    };
+
+    size_t              m_dataPos       = 0;
+    size_t              m_dataLength    = 0;
+    bool                m_isBuffered    = false;            // if TRUE, use m_fp else use m_fd
+    xCustomAllocator*   m_allocator     = &g_DefaultCustomAllocator;
+
+protected:
+    xBaseStream() {
+        m_fp            = nullptr;
+    }
+
+public:
+    virtual             ~xBaseStream    () throw()=0;
+    virtual void        Close           ();
+    virtual const void* GetBufferPtr    (size_t size) const=0;
+    virtual void*       GetBufferPtr    (size_t size)=0;
+            x_off_t     Seek            (x_off_t pos, int whence);
+            x_off_t     Tell            ()              const;
+
+            void        SetCustomAlloc  (xCustomAllocator& allocator)   { m_allocator = &allocator; }
+            bool        IsMemory        ()              const   { return  !m_fp;  }
+            bool        IsFile          ()              const   { return !!m_fp; }
+            bool        IsOK            ()              const   { return !!m_fp || !!m_dataLength; }
+            FILE*       GetFILE         ()                      { return m_isBuffered ? m_fp : nullptr; }
+};
+
+inline xBaseStream::~xBaseStream() throw() {}
+
+
+// ======================================================================================
+//  xStreamReader (class)
+// ======================================================================================
+class xStreamReader : public xBaseStream
+{
+    typedef xBaseStream __parent;
+
+protected:
+    const u8*   m_data;
+
+public:
+                        xStreamReader   ()          { }
+    virtual             ~xStreamReader  () throw() { Close(); }
+    virtual void        Close           ()                          override;
+    virtual const void* GetBufferPtr    (size_t size) const         override;
+    virtual void*       GetBufferPtr    (size_t size)               override;
+            bool        OpenFile        ( const xString& filename );
+            bool        OpenFileBuffered( const xString& filename );
+            bool        OpenMem         ( const void* mem, size_t buffer_length );
+            bool        Read            ( void* dest, ssize_t bytes );
+
+    // Valid for both file and data streams in xStreamReader.
+            size_t      GetLength       ()              const   { return m_dataLength; }
+
+    template< typename T >
+    bool Read( T& dest )
+    {
+        serialization_assert(T);
+        return Read( &dest, sizeof(T) );
+    }
+};
+
+struct xStatInfo
+{
+    u32         st_mode;
+    s64         st_size;
+
+    time_t      time_accessed;
+    time_t      time_modified;
+    time_t      time_created;
+
+    bool IsFile     () const;
+    bool IsDir      () const;
+    bool Exists     () const;
+
+};
+
+extern xStatInfo    xFileStat               (const xString& path);
+extern bool         xFileRename             (const xString& src, const xString& dst);
+extern bool         xCreateDirectory        (const xString& dir);
+extern FILE*        xFopen                  (const xString& fullpath, const char* mode);
+
+extern void         xFileSetSize            (int fd, size_t filesize);
+extern bool         xFgets                  (xString& dest, FILE* stream);
+
+
+// Writes directly to debug console where supported (visual studio), or stdout otherwise.
+extern void     xOutputString       (const char* str, FILE* std_fp);
+

--- a/CraftEngine/ajek-framework/h/x-stdlib.h
+++ b/CraftEngine/ajek-framework/h/x-stdlib.h
@@ -8,7 +8,6 @@
 
 #include <cstring>      // needed for memset
 #include <type_traits>
-#include <cstdio>
 
 #define serialization_assert(T) \
     static_assert(xIs_trivially_copyable(T), "Cannot serialize non-POD object.")
@@ -52,134 +51,6 @@ public:
     }
 };
 
-
-
-// ======================================================================================
-//  xCustomAllocator  (interface)
-// ======================================================================================
-class xCustomAllocator {
-public:
-    virtual void*       alloc       (size_t size)               =0;
-    virtual void*       realloc     (void* ptr, size_t size)    =0;
-    virtual void        free        (void* ptr)                 =0;
-};
-
-class xDefaultCustomAllocator : public xCustomAllocator {
-public:
-    void*       alloc       (size_t size)               override;
-    void*       realloc     (void* ptr, size_t size)    override;
-    void        free        (void* ptr)                 override;
-};
-
-extern xDefaultCustomAllocator  g_DefaultCustomAllocator;
-
-// ======================================================================================
-//  xBaseStream (abstract class)
-// ======================================================================================
-class xBaseStream
-{
-    NONCOPYABLE_OBJECT( xBaseStream );
-
-protected:
-    union {
-        // We cheat her a bit -- m_fd strictly speaking should be -1 for an empty descriptor.
-        // The API manually sets -1 to zero (0) within OpenFile() to allow !nullptr checks
-        // against m_fp to satisfy either underlying file system.  This is ok because posix
-        // fd==0 is reserved as stdin anyway, and will never be returned from open(). --jstine
-
-        FILE*       m_fp;               // non-NULL implies data is sourced from file
-        int         m_fd;
-    };
-
-    size_t              m_dataPos       = 0;
-    size_t              m_dataLength    = 0;
-    bool                m_isBuffered    = false;            // if TRUE, use m_fp else use m_fd
-    xCustomAllocator*   m_allocator     = &g_DefaultCustomAllocator;
-
-protected:
-    xBaseStream() {
-        m_fp            = nullptr;
-    }
-
-public:
-    virtual             ~xBaseStream    () throw()=0;
-    virtual void        Close           ();
-    virtual const void* GetBufferPtr    (size_t size) const=0;
-    virtual void*       GetBufferPtr    (size_t size)=0;
-            x_off_t     Seek            (x_off_t pos, int whence);
-            x_off_t     Tell            ()              const;
-
-            void        SetCustomAlloc  (xCustomAllocator& allocator)   { m_allocator = &allocator; }
-            bool        IsMemory        ()              const   { return  !m_fp;  }
-            bool        IsFile          ()              const   { return !!m_fp; }
-            bool        IsOK            ()              const   { return !!m_fp || !!m_dataLength; }
-            FILE*       GetFILE         ()                      { return m_isBuffered ? m_fp : nullptr; }
-};
-
-inline xBaseStream::~xBaseStream() throw() {}
-
-
-// ======================================================================================
-//  xStreamReader (class)
-// ======================================================================================
-class xStreamReader : public xBaseStream
-{
-    typedef xBaseStream __parent;
-
-protected:
-    const u8*   m_data;
-
-public:
-                        xStreamReader   ()          { }
-    virtual             ~xStreamReader  () throw() { Close(); }
-    virtual void        Close           ()                          override;
-    virtual const void* GetBufferPtr    (size_t size) const         override;
-    virtual void*       GetBufferPtr    (size_t size)               override;
-            bool        OpenFile        ( const xString& filename );
-            bool        OpenFileBuffered( const xString& filename );
-            bool        OpenMem         ( const void* mem, size_t buffer_length );
-            bool        Read            ( void* dest, ssize_t bytes );
-
-    // Valid for both file and data streams in xStreamReader.
-            size_t      GetLength       ()              const   { return m_dataLength; }
-
-    template< typename T >
-    bool Read( T& dest )
-    {
-        serialization_assert(T);
-        return Read( &dest, sizeof(T) );
-    }
-};
-
-struct xStatInfo
-{
-    u32         st_mode;
-    s64         st_size;
-
-    time_t      time_accessed;
-    time_t      time_modified;
-    time_t      time_created;
-
-    bool IsFile     () const;
-    bool IsDir      () const;
-    bool Exists     () const;
-
-};
-
-
-extern void     xMalloc_Check       ();
-extern void*    xMalloc             (size_t sz);
-extern void*    xCalloc             (size_t numItems, size_t sz);
-extern void*    xRealloc            (void* srcptr, size_t sz);
-extern void     xFree               (void *ptr);
-extern void*    xMalloc_Aligned     (size_t sz, u32 align);
-extern void*    xRealloc_Aligned    (void* srcptr, size_t sz, u32 align);
-extern void     xFree_Aligned       (void* ptr);
-extern void     xMalloc_Report      ();
-extern void     xMalloc_ReportDelta ();
-
-#define placement_new(T)        new (xMalloc(sizeof(T))) T
-
 template<typename T>
 void placement_delete(T* ptr)   { (ptr)->~T(); xFree(ptr); }
 
@@ -195,41 +66,9 @@ extern void         xMemCopyQwc_WrappedSrc  (u128* dest,        const u128* srcB
 extern void         xMemCopyShortQwc        (void* dest, const void* src, uint lenQwc);
 extern void         xMemCopyShortQwc_NT     (void* dest, const void* src, uint lenQwc);
 
-extern xStatInfo    xFileStat               (const xString& path);
-extern bool         xFileRename             (const xString& src, const xString& dst);
-extern bool         xCreateDirectory        (const xString& dir);
-extern FILE*        xFopen                  (const xString& fullpath, const char* mode);
-
-extern void         xFileSetSize            (int fd, size_t filesize);
-extern bool         xFgets                  (xString& dest, FILE* stream);
-
 extern bool         xEnvironExists          (const xString& varname);
 extern xString      xEnvironGet             (const xString& varname);
 extern void         xEnvironSet             (const xString& varname, const xString& value, bool overwrite=1);
-
-
-// Performs cleanup of existing object pointer (if non-null) and creates a new object in its place.
-// Memory is allocated if the provided pointer is null.
-template< typename T >
-__xi T* xMallocNew(T* &ptr)
-{
-    if (ptr) {
-        ptr->~T();
-    }
-    else {
-        ptr = (T*)xMalloc(sizeof(*ptr));
-    }
-    return new (ptr) T();
-}
-
-// Memory is allocated if the provided pointer is null.  if pointer is non-null, then no action is taken.
-template< typename T >
-__xi T* xMallocT(T* &ptr)
-{
-    static_assert(!std::has_virtual_destructor<T>::value, "Non-trivial type has meaningful destructor.  Use xMallocNew<T> instead.");
-    //static_assert(!std::is_trivially_copyable<T>::value, "Non-trivial type has meaningful destructor.  Use xMallocNew<T> instead.")
-    return ptr ? ptr : xMalloc(sizeof(*ptr));
-}
 
 template< typename T >
 inline void xMemMove(T* dest, size_t destLen, const T* src, size_t srcLen)

--- a/CraftEngine/ajek-framework/h/x-types.h
+++ b/CraftEngine/ajek-framework/h/x-types.h
@@ -899,10 +899,6 @@ inline __ai bool IsInInt32u(u64 x)  { return (x <= 0xFFFFFFFFUL); }
 #   define __FUNCTION_NAME__        ((const char*)__FUNCTION__)
 #endif
 
-#define DECLARE_MODULE_NAME_CLASS( name )   static      __unused const char* const s_ModuleName;
-#define DECLARE_MODULE_NAME_LOCAL( name )   static      __unused const char* const s_ModuleName = name;
-#define DECLARE_MODULE_NAME( name )         namespace { __unused const char* const s_ModuleName = name; }
-
 // -------------------------------------------------------------
 //                     C++ Class Macros
 // -------------------------------------------------------------

--- a/CraftEngine/ajek-framework/msbuild/ajek-framework.vcxproj
+++ b/CraftEngine/ajek-framework/msbuild/ajek-framework.vcxproj
@@ -110,6 +110,8 @@
     <ClInclude Include="..\h\x-png-encode.h" />
     <ClInclude Include="..\h\x-ScopedMalloc.h" />
     <ClInclude Include="..\h\x-simd.h" />
+    <ClInclude Include="..\h\x-stdalloc.h" />
+    <ClInclude Include="..\h\x-stdfile.h" />
     <ClInclude Include="..\h\x-stdlib.h" />
     <ClInclude Include="..\h\x-stl.h" />
     <ClInclude Include="..\h\x-string.h" />

--- a/CraftEngine/ajek-framework/msbuild/ajek-framework.vcxproj.filters
+++ b/CraftEngine/ajek-framework/msbuild/ajek-framework.vcxproj.filters
@@ -123,6 +123,12 @@
     <ClInclude Include="..\h\x-unipath.h">
       <Filter>Public Includes</Filter>
     </ClInclude>
+    <ClInclude Include="..\h\x-stdfile.h">
+      <Filter>Public Includes</Filter>
+    </ClInclude>
+    <ClInclude Include="..\h\x-stdalloc.h">
+      <Filter>Public Includes</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Public Includes">

--- a/CraftEngine/ajek-framework/src/imgtools.cpp
+++ b/CraftEngine/ajek-framework/src/imgtools.cpp
@@ -5,7 +5,6 @@
 
 using namespace imgtool;
 
-DECLARE_MODULE_NAME("imgtool");
 DECLARE_MODULE_THROW(xThrowModule_Bridge);
 
 static __ai void _imt_copyscan(const u32* srcptr, u32* destptr, int copylen)

--- a/CraftEngine/ajek-framework/src/kpad.cpp
+++ b/CraftEngine/ajek-framework/src/kpad.cpp
@@ -10,8 +10,6 @@
 #include "x-pad.h"
 #include "x-host-ifc.h"
 
-DECLARE_MODULE_NAME("kpad");
-
 #if 0
 #   define trace_kpad(...)      log_host( __VA_ARGS__ )
 #else

--- a/CraftEngine/ajek-framework/src/msw/msw-GetLastError.cpp
+++ b/CraftEngine/ajek-framework/src/msw/msw-GetLastError.cpp
@@ -6,11 +6,6 @@
 #include <fcntl.h>
 
 
-namespace {
-    const char* s_ModuleName = nullptr;     // this module name is not relevant to the errors it logs
-};
-
-
 // --------------------------------------------------------------------------------------
 void msw_AttachToParentConsole()
 {

--- a/CraftEngine/ajek-framework/src/msw/msw-keyboard.cpp
+++ b/CraftEngine/ajek-framework/src/msw/msw-keyboard.cpp
@@ -3,8 +3,6 @@
 #include "msw-redtape.h"
 #include "x-host-ifc.h"
 
-DECLARE_MODULE_NAME("x-kbd");
-
 extern HWND g_hWnd;     // must be provided by application's msw-WinMain.cpp
 
 // ConvertFromMswVK

--- a/CraftEngine/ajek-framework/src/msw/msw-thread.cpp
+++ b/CraftEngine/ajek-framework/src/msw/msw-thread.cpp
@@ -7,8 +7,6 @@
 
 #include "x-atomic.h"
 
-DECLARE_MODULE_NAME( "msw-thread" );
-
 // needed for thread profiling.
 void msw_CloneCurrentThread( thread_t& dest )
 {

--- a/CraftEngine/ajek-framework/src/x-png-decode.cpp
+++ b/CraftEngine/ajek-framework/src/x-png-decode.cpp
@@ -1,6 +1,8 @@
 
 #include "PCH-framework.h"
 #include "x-png-decode.h"
+#include "x-stdfile.h"
+
 #include "png.h"
 
 void png_LoadFromFile(xBitmapData& dest, const xString& filename)

--- a/CraftEngine/ajek-framework/src/x-png-encode.cpp
+++ b/CraftEngine/ajek-framework/src/x-png-encode.cpp
@@ -1,6 +1,7 @@
 
 #include "PCH-framework.h"
 #include "x-assertion.h"
+#include "x-stdfile.h"
 #include "x-png-encode.h"
 #include "png.h"
 

--- a/CraftEngine/ajek-framework/src/x-stdlib.cpp
+++ b/CraftEngine/ajek-framework/src/x-stdlib.cpp
@@ -1,6 +1,9 @@
 
 #include "PCH-framework.h"
+
+#include "x-types.h"
 #include "x-chrono.h"
+#include "x-stdfile.h"
 
 #if USE_GLIBC_MACRO_FIXUP
 #   undef __unused
@@ -23,8 +26,6 @@
 #   define __unused     __UNUSED
 #   define __xi         __ALWAYS_INLINE_FUNCTION
 #endif
-
-DECLARE_MODULE_NAME( "x-stdlib" );
 
 #include "x-MemCopy.inl"
 

--- a/CraftEngine/ajek-framework/src/x-string.cpp
+++ b/CraftEngine/ajek-framework/src/x-string.cpp
@@ -6,8 +6,6 @@
 #include "x-string.h"
 
 
-DECLARE_MODULE_NAME( "x-string" );
-
 //
 // Converts a u32 to a binary string.
 // [TODO] : Rename this to "binaryToString()" or something slightly more obvious.

--- a/CraftEngine/ajek-gpu/h/x-gpu-ifc.h
+++ b/CraftEngine/ajek-gpu/h/x-gpu-ifc.h
@@ -3,6 +3,7 @@
 #include "x-types.h"
 #include "x-simd.h"
 #include "x-BitmapData.h"
+#include "x-stdlib.h"
 
 enum GPU_ResourceFmt : u8
 {

--- a/CraftEngine/ajek-gpu/src/msw/dx11-core_stuff.cpp
+++ b/CraftEngine/ajek-gpu/src/msw/dx11-core_stuff.cpp
@@ -22,8 +22,6 @@
 #include <unordered_map>
 #include <unordered_set>
 
-DECLARE_MODULE_NAME("dx11");
-
 #include "x-MemCopy.inl"
 
 DECLARE_MODULE_THROW(xThrowModule_GPU);     // enables use of throw_abort() macro
@@ -219,7 +217,7 @@ void dx11_Release(T*& resource)
     if (!resource) return;
 
     if (dx11_ObjectReportEnabled()) {
-        log_host("(runtime) Releasing managed object @ %s", cPtrStr(resource, ""));
+        log_host("[dx11](runtime) Releasing managed object @ %s", cPtrStr(resource, ""));
     }
 
 #if DX11_DEBUG_FLAG_SUPPORT
@@ -353,7 +351,7 @@ void dx11_CleanupDevice()
 #if DX11_DEBUG_FLAG_SUPPORT
     for(auto& ref : s_dx11_managed_objects) {
         if (dx11_ObjectReportEnabled()) {
-            log_host("(Cleanup) Releasing managed object @ %s", cPtrStr(ref, ""));
+            log_host("[dx11](Cleanup) Releasing managed object @ %s", cPtrStr(ref, ""));
         }
         ((IUnknown*)ref)->Release();
     }
@@ -775,7 +773,7 @@ ID3D11InputLayout* do_prep_inputLayout()
     newCacheItem.inputDescHash = s_CurrentInputDesc->GetHash();
 
     pragma_todo("Add user-defined long-name description to InputDesc for logging and debugging.");
-    log_perf( "Adding new InputLayout to cache, hash=0x%08x count=%d", fullhash_vs, s_dx11_InputLayoutCache.size() );
+    log_perf( "[dx11] Adding new InputLayout to cache, hash=0x%08x count=%d", fullhash_vs, s_dx11_InputLayoutCache.size() );
 
     HRESULT hr;
     hr = g_pd3dDevice->CreateInputLayout(

--- a/CraftEngine/ajek-script/src/ajek-script.cpp
+++ b/CraftEngine/ajek-script/src/ajek-script.cpp
@@ -14,7 +14,6 @@ extern "C" {
 #   include "linit.c"
 }
 
-DECLARE_MODULE_NAME("lua-main");
 DECLARE_MODULE_THROW(xThrowModule_Script);
 
 AjekScriptSettings      g_ScriptConfig;
@@ -47,10 +46,10 @@ bool AjekScript_LoadConfiguration(AjekScriptEnv& env)
         g_ScriptConfig.lua_print_enabled = scriptConfig.get_bool    ("LuaPrintEnable");
 
         if (g_ScriptConfig.path_to_modules != old_script_config.path_to_modules) {
-            log_host_loud("   > ModulePath = %s", g_ScriptConfig.path_to_modules.c_str());
+            log_host("   > ModulePath = %s", g_ScriptConfig.path_to_modules.c_str());
         }
         if (!g_ScriptConfig.lua_print_enabled || (g_ScriptConfig.lua_print_enabled != old_script_config.lua_print_enabled)) {
-            log_host_loud("   > Lua Print has been turned %s!", g_ScriptConfig.lua_print_enabled ? "ON" : "OFF");
+            log_host("   > Lua Print has been turned %s!", g_ScriptConfig.lua_print_enabled ? "ON" : "OFF");
         }
     }
 
@@ -170,7 +169,7 @@ extern "C" void ajek_lua_printf(const char *fmt, ...)
 {
     va_list list;
     va_start(list, fmt);
-    _host_log_v(xLogFlag_Important, "Lua", fmt, list);
+    log_host_v(fmt, list);
     flush_log();
     va_end(list);
 }

--- a/CraftEngine/ajekscript-interpreter/ajekscript-interpreter.cpp
+++ b/CraftEngine/ajekscript-interpreter/ajekscript-interpreter.cpp
@@ -60,7 +60,7 @@ assert_t xDebugBreak_v( DbgBreakType breakType, const AssertContextInfoTriad& tr
     return assert_break;
 }
 
-void _host_log(uint flags, const char* moduleName, const char* fmt, ...)
+void log_host(const char* fmt, ...)
 {
     if (fmt && fmt[0])
     {
@@ -69,6 +69,14 @@ void _host_log(uint flags, const char* moduleName, const char* fmt, ...)
         vprintf(fmt, list);
         va_end(list);
         printf("\n");
+    }
+}
+
+void log_host_v(const char* fmt, va_list list)
+{
+    if (fmt && fmt[0])
+    {
+        vprintf(fmt, list);
     }
 }
 
@@ -108,8 +116,6 @@ extern "C" void ajek_lua_ChunkId_Filename(char* out, const char* source, size_t 
         memcpy(out, result.c_str() + l - bufflen, bufflen * sizeof(char) + 1);
     }
 }
-
-DECLARE_MODULE_NAME("as-int");
 
 extern "C" void ajek_warn_new_global(lua_State* L)
 {

--- a/CraftEngine/src/CliConfigOption.cpp
+++ b/CraftEngine/src/CliConfigOption.cpp
@@ -1,6 +1,7 @@
 #include "PCH-rpgcraft.h"
 
 #include "x-types.h"
+#include "x-stdfile.h"
 #include "ajek-script.h"
 #include "appConfig.h"
 
@@ -10,8 +11,6 @@
 
 static std::vector<xString> s_asset_search_dirs;
 static bool s_release_check_mode = false;
-
-DECLARE_MODULE_NAME("CliOpt");
 
 enum CliResultType
 {

--- a/CraftEngine/src/Entity.cpp
+++ b/CraftEngine/src/Entity.cpp
@@ -11,9 +11,6 @@
 
 #include <unordered_set>
 
-DECLARE_MODULE_NAME("Entity");
-
-
 // Entity Engineering Thoughts:
 //   Currently supporting managed and unmanaged entities for sake of completeness.  Unmnaged entities
 //   are typically static (persisitent) objects within C++ for which pointers are always valid.  There's

--- a/CraftEngine/src/PlayerSprite.cpp
+++ b/CraftEngine/src/PlayerSprite.cpp
@@ -12,8 +12,6 @@
 #include "Scene.h"
 #include "Mouse.h"
 
-DECLARE_MODULE_NAME("player");
-
 GPU_ConstantBuffer      gpu_constbuf;
 GPU_TextureResource2D   tex_camel[4][3];
 GPU_TextureResource2D   tex_hero [4][3];

--- a/CraftEngine/src/Scene.cpp
+++ b/CraftEngine/src/Scene.cpp
@@ -22,8 +22,6 @@
 #include <queue>
 #include <ctime>
 
-DECLARE_MODULE_NAME("scene");
-
 typedef std::queue<SceneMessage> SceneMessageList;
 
 static thread_t             s_thr_scene_producer;

--- a/CraftEngine/src/TileMapLayer.cpp
+++ b/CraftEngine/src/TileMapLayer.cpp
@@ -9,8 +9,6 @@
 #include "TileMapLayer.h"
 #include "DbgFont.h"
 
-DECLARE_MODULE_NAME("TileMap");
-
 // Probably need some sort of classification system here.
 // Some terrains may change over time, such as grow moss after being crafted.
 //  - Maybe better handled as a generic "age" engine feature?

--- a/CraftEngine/src/appConfig.cpp
+++ b/CraftEngine/src/appConfig.cpp
@@ -2,14 +2,13 @@
 #include "PCH-rpgcraft.h"
 
 #include "x-types.h"
+#include "x-stdfile.h"
 #include "x-stl.h"
 #include "x-assertion.h"
 
 #include "appConfig.h"
 #include "ajek-script.h"
 
-
-DECLARE_MODULE_NAME("config");
 
 HostwindowSettings g_settings_hostwnd;
 

--- a/CraftEngine/src/fmod-ifc.cpp
+++ b/CraftEngine/src/fmod-ifc.cpp
@@ -28,7 +28,6 @@ enum {
     AudioGroup_UI,
 };
 
-DECLARE_MODULE_NAME("fmod");
 DECLARE_MODULE_THROW(xThrowModule_FMOD);
 
 #define check_result(res)   res && bug("FMOD Error 0x%08x: %s", res, fmod_result_toString(res))

--- a/CraftEngine/src/main.cpp
+++ b/CraftEngine/src/main.cpp
@@ -30,8 +30,6 @@
 
 using namespace DirectX;
 
-DECLARE_MODULE_NAME("main");
-
 GPU_IndexBuffer         g_idx_box2D;
 GPU_ShaderVS            g_ShaderVS_Tiler;
 GPU_ShaderFS            g_ShaderFS_Tiler;

--- a/CraftEngine/src/msw-WinMain.cpp
+++ b/CraftEngine/src/msw-WinMain.cpp
@@ -18,8 +18,6 @@
 
 #include <direct.h>     // for _getcwd()
 
-DECLARE_MODULE_NAME("winmain");
-
 extern void         LogHostInit();
 extern void         MSW_InitChrono();
 extern VirtKey_t    ConvertFromMswVK( UINT key );
@@ -581,7 +579,7 @@ void xOutputStringError(const char* str)
     }
 }
 
-void xOutputString(const char* str)
+void xOutputString(const char* str, FILE* std_fp)
 {
 #if MSW_ENABLE_DEBUG_OUTPUT
     if (::IsDebuggerPresent())

--- a/CraftEngine/src/test-spline.cpp
+++ b/CraftEngine/src/test-spline.cpp
@@ -10,8 +10,6 @@
 
 #include "Bezier2d.inl"
 
-DECLARE_MODULE_NAME("spline");
-
 static const int const_zval = 0.1f;
 
 static const int        numStepsPerCurve        = 10;

--- a/CraftEngine/src/x-DebugUtil.cpp
+++ b/CraftEngine/src/x-DebugUtil.cpp
@@ -3,6 +3,7 @@
 
 #include "x-types.h"
 #include "x-string.h"
+#include "x-stdfile.h"
 
 
 xString xGetTempDir()


### PR DESCRIPTION
Removes module-scope prefixes, WARN prefixes, and timestamp prefixes.  Most of these things were hold-overs from things other people added to my library as I've been bringing it along with me from project to project... and while I _kind_ of liked the module scope prefix, it was a pain when it came to C++ classes, or printing multi-line text where prefixes interfere with other things.  Adding prefixes manually, as it turns out, is pretty damn easy too.  Easier, in most cases, than adding module-scope `char*` definitions.

So it's gone!