### PR TITLE
fmod-ifc: add mute channel control functions

### DIFF
--- a/CraftEngine/src/fmod-ifc.cpp
+++ b/CraftEngine/src/fmod-ifc.cpp
@@ -223,6 +223,22 @@ void fmod_SetVolume(const FmodMusic& stream, float vol)
     check_result(result);
 }
 
+void fmod_SetMute(const FmodMusic& stream, bool is_muted)
+{
+    if (!stream.channel) return;
+    auto result = FMOD_Channel_SetMute(stream.channel, is_muted);
+    check_result(result);
+}
+
+bool fmod_GetMute(const FmodMusic& stream)
+{
+    if (!stream.channel) return true;
+    FMOD_BOOL is_muted;
+    auto result = FMOD_Channel_GetMute(stream.channel, &is_muted);
+    check_result(result);
+    return bool(is_muted);
+}
+
 FMOD_CHANNEL* fmod_PlaySound(const FmodSound& sound)
 {
     if (!sound.sndptr) {

--- a/CraftEngine/src/fmod-ifc.h
+++ b/CraftEngine/src/fmod-ifc.h
@@ -26,5 +26,8 @@ extern void             fmod_Play           (FmodMusic& stream);
 extern void             fmod_SetPause       (FmodMusic& stream, bool isPaused);
 extern void             fmod_SetVolume      (const FmodMusic& stream, float vol);
 extern void             fmod_SetVolume      (FMOD_CHANNEL* channel, float volume);
+extern void             fmod_SetMute        (const FmodMusic& stream, bool is_muted);
+extern bool             fmod_GetMute        (const FmodMusic& stream);
+
 
 extern FMOD_CHANNEL*    fmod_PlaySound      (const FmodSound& sound);


### PR DESCRIPTION
Unused as of yet, but I tested them locally in some yet-to-be-PR'd code.  Just like to isolate this into its own PR diff.