### PR TITLE
x-string: optimize using reference-array syntax: char (&src)[]

### DIFF
--- a/CraftEngine/ajek-framework/h/x-string.h
+++ b/CraftEngine/ajek-framework/h/x-string.h
@@ -244,12 +244,12 @@ public:
 
 
 template<int src_len>
-inline __ni xString operator+( const xString& right, const char (&src)[src_len] )
+inline __ai xString operator+( const xString& right, const char (&src)[src_len] )
 {
     return xString(right).Append( src );
 }
 
-inline __ni xString operator+( const xString& right, const xString& src )
+inline __ai xString operator+( const xString& right, const xString& src )
 {
     return xString(right).Append( src );
 }

--- a/CraftEngine/ajek-framework/src/x-string.cpp
+++ b/CraftEngine/ajek-framework/src/x-string.cpp
@@ -28,13 +28,6 @@ char* sbinary(u32 val)
     return  &bchars[0];
 }
 
-
-qstringlen::qstringlen(const char* src) {
-    strptr = src;
-    length = strlen(src);
-}
-
-
 // ----------------------------------------------------------------------------
 //  toUTF16 / toUTF8  (implementations)
 // ----------------------------------------------------------------------------
@@ -305,7 +298,7 @@ xString& xString::AppendFmtV( const char* fmt, va_list list )
     if (!fmt) return *this;
 
     size_t origlen  = GetLength();
-    int destSize    = _vscprintf( fmt, list );
+    int destSize    = fmt ? _vscprintf( fmt, list ) : 0;
 
     bug_on_qa( destSize < 0, "Invalid string formatting parameters! -- or nasty old glibc?" );
     if (destSize==0) return *this;      // don't waste time appending nothing.


### PR DESCRIPTION
This also allows disambiguation of xString& vs. const char* for overloaded functions!

This does officially make `qstringlen` obsolete.  Honestly, dunno why I didn't think of this sooner.