### PR TITLE
add imgui-reset-ini=[0,1] and xFileUnlink

### DIFF
--- a/CraftEngine/ajek-framework/h/x-stdfile.h
+++ b/CraftEngine/ajek-framework/h/x-stdfile.h
@@ -100,6 +100,7 @@ struct xStatInfo
 
 extern xStatInfo    xFileStat               (const xString& path);
 extern bool         xFileRename             (const xString& src, const xString& dst);
+extern void         xFileUnlink             (const xString& src);
 extern bool         xCreateDirectory        (const xString& dir);
 extern FILE*        xFopen                  (const xString& fullpath, const char* mode);
 

--- a/CraftEngine/ajek-framework/h/x-unipath.h
+++ b/CraftEngine/ajek-framework/h/x-unipath.h
@@ -5,6 +5,7 @@
 
 #include "x-types.h"
 #include "x-string.h"
+#include "x-stdfile.h"
 
 enum xPathLayout
 {
@@ -32,6 +33,10 @@ struct xUniPath
 
 extern  void        xPathSetLibcLayout      (xPathLayout layout);
 extern  xUniPath    xUniPathInit            (const xString& src);
+
+extern  void        xFileUnlink             (const xUniPath& src);
+extern  bool        xFileRename             (const xUniPath& src_, const xUniPath& dest_);
+extern  xStatInfo   xFileStat               (const xUniPath& upath);
 
 extern  xString     xBaseFilename           (const xUniPath& src);
 extern  xString     xDirectoryName          (const xUniPath& src);

--- a/CraftEngine/ajek-framework/src/x-stdlib.cpp
+++ b/CraftEngine/ajek-framework/src/x-stdlib.cpp
@@ -144,6 +144,15 @@ void xFileSetSize( int fd, size_t filesize )
     }
 }
 
+void xFileUnlink(const xUniPath& src)
+{
+#if defined(TARGET_MSW)
+    _unlink(src.GetLibcStr());
+#else
+	unlink(src.GetLibcStr());
+#endif
+}
+
 // --------------------------------------------------------------------------------------
 bool xFileRename( const xUniPath& src_, const xUniPath& dest_ )
 {
@@ -337,6 +346,11 @@ xStatInfo xFileStat(const xString& path)
 bool xFileRename(const xString& src_, const xString& dest_)
 {
     return xFileRename(xUniPathInit(src_), xUniPathInit(dest_));
+}
+
+void xFileUnlink(const xString& src)
+{
+    xFileUnlink(xUniPathInit(src));
 }
 
 bool xCreateDirectory( const xString& dir ) {

--- a/CraftEngine/src/CliConfigOption.cpp
+++ b/CraftEngine/src/CliConfigOption.cpp
@@ -4,6 +4,7 @@
 #include "x-stdfile.h"
 #include "ajek-script.h"
 #include "appConfig.h"
+#include "imgui.h"
 
 #include "x-stl.h"
 #include <type_traits>
@@ -278,6 +279,15 @@ static const CliOptionDesc s_valid_options_list[] = {
     { "audio-sfx-mute"              ,[](const xString& value){ to_bool(g_settings_audio.sfx_muted, value); }},
     { "audio-nav-mute"              ,[](const xString& value){ to_bool(g_settings_audio.nav_muted, value); }},
     { "audio-vod-mute"              ,[](const xString& value){ to_bool(g_settings_audio.vod_muted, value); }},
+
+
+    { "imgui-reset-ini"             ,[](const xString& value){
+        bool do_reset = false; to_bool(do_reset, value);
+        if (do_reset) {
+            xFileUnlink(ImGui::GetIO().IniFilename);
+            log_host("[imgui-reset-ini] Deleted imgui configuration file '%s'", ImGui::GetIO().IniFilename);
+        }
+    }},
 
     // Visual Studio script debug mode:
     // Script error messages should be printed relative to the solution directory.


### PR DESCRIPTION
 * CLI option `imgui-reset-ini=1` deletes the existing imgui.ini on startup

 * `unlink` only works on files and not on directories.  Deleting directories is hard on Windows (requires using ShellExec or something annoying).