### PR TITLE
x-png-encode: support 24, 48, and 64-bit color formats 

### DIFF
--- a/CraftEngine/ajek-framework/h/x-png-encode.h
+++ b/CraftEngine/ajek-framework/h/x-png-encode.h
@@ -12,7 +12,7 @@ private:
     u8** lines      = nullptr;
     s32  width      = 0;
     s32  height     = 0;
-    u32  bbp        = 0;
+    u32  bpp        = 0;
     bool reverseRGB = 0;
 
 public:
@@ -20,9 +20,13 @@ public:
 
     void            Cleanup             ();
     x_png_enc&      WriteImage          (const xBitmapDataRO& bitmap, bool reverseRGB_ = false);
-    x_png_enc&      WriteImage          (const void* data, s32 width_, s32 height_, u32 bbp_ = 32, bool reverseRGB_ = false);
+    x_png_enc&      WriteImage          (const void* data, s32 width_, s32 height_, u32 bpp_ = 32, bool reverseRGB_ = false);
     int             SaveImage           (const char* filename, int compression_level = 9);      // Compression level is from 0~9 (0=none, 9=max)
     x_png_enc&      ClearAlphaChannel   (u8 alpha = 255);
+    x_png_enc&      Cvt64to32           ();
+    x_png_enc&      Cvt64to24           ();
+    x_png_enc&      Cvt64to48           ();
+    x_png_enc&      Cvt32to24           ();
 
 };
 

--- a/CraftEngine/ajek-framework/h/x-png-encode.h
+++ b/CraftEngine/ajek-framework/h/x-png-encode.h
@@ -12,7 +12,7 @@ private:
     u8** lines      = nullptr;
     s32  width      = 0;
     s32  height     = 0;
-    u32  bpp        = 0;
+    s32  bpp        = 0;
     bool reverseRGB = 0;
 
 public:
@@ -20,12 +20,14 @@ public:
 
     void            Cleanup             ();
     x_png_enc&      WriteImage          (const xBitmapDataRO& bitmap, bool reverseRGB_ = false);
-    x_png_enc&      WriteImage          (const void* data, s32 width_, s32 height_, u32 bpp_ = 32, bool reverseRGB_ = false);
+    x_png_enc&      WriteImage          (const void* data, s32 width_, s32 height_, s32 bpp_ = 32, bool reverseRGB_ = false);
     int             SaveImage           (const char* filename, int compression_level = 9);      // Compression level is from 0~9 (0=none, 9=max)
     x_png_enc&      ClearAlphaChannel   (u8 alpha = 255);
-    x_png_enc&      Cvt64to32           ();
-    x_png_enc&      Cvt64to24           ();
+    x_png_enc&      StripAlphaChannel   ();
+    x_png_enc&      DownSample          ();
+    x_png_enc&      CvtTo24             ();
     x_png_enc&      Cvt64to48           ();
+    x_png_enc&      Cvt64to24           ();
     x_png_enc&      Cvt32to24           ();
 
 };


### PR DESCRIPTION
API is structured for simplicity over flexibility.  The expectation is that common case actions are stripping alpha channel or downgrading the bit depth.  Typical problem with png saving is speed of compression and output file size.  Downgrading alphg and bitdepth aid in reducing that problem.  Converting from lower to higher bitdepth or adding alpha before saving never makes sense.