### PR TITLE
Fixed C++ union constructor violation in float2/float4/Box2D

### DIFF
--- a/CraftEngine/Box2D.cpp
+++ b/CraftEngine/Box2D.cpp
@@ -7,8 +7,8 @@ Box2D::~Box2D()
 
 void Box2D::buildFrom(float2 origin, float halfWidth, float halfHeight)
 {
-    m_topLeft = float2(origin.x - halfWidth, origin.y + halfHeight);
-    m_bottomRight = float2(origin.x + halfWidth, origin.y - halfHeight);
+    m_topLeft     = {origin.x - halfWidth, origin.y + halfHeight};
+    m_bottomRight = {origin.x + halfWidth, origin.y - halfHeight};
     normalize();
 }
 

--- a/CraftEngine/Box2D.h
+++ b/CraftEngine/Box2D.h
@@ -2,7 +2,7 @@
 class Box2D
 {
 public:
-    Box2D(float2 topLeft, float2 bottomRight) 
+    Box2D(float2 topLeft, float2 bottomRight)
         : m_topLeft(topLeft)
         , m_bottomRight(bottomRight)
     {
@@ -16,7 +16,7 @@ public:
 	}
 
 	Box2D(float left, float top, float right, float bottom)
-		: m_topLeft(left, top), m_bottomRight(right, bottom)
+		: m_topLeft({left, top}), m_bottomRight({right, bottom})
 	{
 		normalize();
 	}

--- a/CraftEngine/ajek-framework/h/x-simd.h
+++ b/CraftEngine/ajek-framework/h/x-simd.h
@@ -523,13 +523,13 @@ union float2 {
 
     u64         _i64val;
 
-    float2() :
-        x(0), y(0)
-    {}
-
-    float2(float x, float y)
-        : x(x), y(y)
-    {}
+    // CONSTRUCTORS ARE INTENTIONALLY OMITTED
+    //   Constructors in POD-unions cause problems when those unions are embedded inside other POD-unions.
+    //   Since a main benefit of POD-unions is the ability to build larger/fancier POD-unions from them,
+    //   it becomes important to avoid constructors in them, as a strict rule.
+    //
+    // Use C++14 style initializer lists for constructing this union.  example:
+    //   float2 foobar = { some_val, other_val };
 
     explicit operator int2() const;
 
@@ -598,26 +598,14 @@ union float4 {
 
     __m128  q;
 
-    float4()
-        : x(0), y(0), z(0), w(0)
-    {}
-
-    float4(float x, float y, float z, float w)
-        : x(x), y(y), z(z), w(w)
-    {}
-
-    float4(float x, float y, float z)
-        : x(x), y(y), z(z), w(0)
-    {}
-
-    float4(float x, float y)
-        : x(x), y(y), z(0), w(0)
-    {}
-
-    float4(float x)
-        : x(x), y(0), z(0), w(0)
-    {}
-
+    // CONSTRUCTORS ARE INTENTIONALLY OMITTED
+    //   Constructors in POD-unions cause problems when those unions are embedded inside other POD-unions.
+    //   Since a main benefit of POD-unions is the ability to build larger/fancier POD-unions from them,
+    //   it becomes important to avoid constructors in them, as a strict rule.
+    //
+    // Use C++14 style initializer lists for constructing this union.  example:
+    //   float4 foobar = { some_val, other_val, z, w };
+    //   float4 foobar = { some_val, other_val };       // z and w will be auto-initialized to zero
 
     bool isEmpty() const {
         return i_ptestz(q);
@@ -762,6 +750,14 @@ union uint2 {
     };
 
     u64         _i64val;
+
+    // CONSTRUCTORS ARE INTENTIONALLY OMITTED
+    //   Constructors in POD-unions cause problems when those unions are embedded inside other POD-unions.
+    //   Since a main benefit of POD-unions is the ability to build larger/fancier POD-unions from them,
+    //   it becomes important to avoid constructors in them, as a strict rule.
+    //
+    // Use C++14 style initializer lists for constructing this union.  example:
+    //   int2 foobar = { some_val, other_val };
 
     explicit operator float2 () const;
     explicit operator vFloat2() const;


### PR DESCRIPTION
This PR is of particular interest!  Review the changes I made to `Box2D`.  It might look like alien or unfamiliar syntax at first.  C++14's implicit type deduction for `{}` initializer lists is kind of an amazingly powerful tool.

Notes have been added to the unions explaining why they intentionally do not have constructors, and the intention to use C++14's very nifty and incredibly powerful initializer-list syntax in place of the redtape-laden constructors that also break handy union things.

This PR fixes an error which shows up in clang/gcc when you try to nest non-trivial unions inside of other unions.  Visual C++ ignores the error even though it's clearly forbidden per C++ Standard Rules.
