### PR TITLE
Windowless operation, for use by CI and verification

### DIFF
--- a/CraftEngine/ajek-framework/src/msw/msw-keyboard.cpp
+++ b/CraftEngine/ajek-framework/src/msw/msw-keyboard.cpp
@@ -141,6 +141,7 @@ UINT ConvertToMswVK( VirtKey_t ours )
 
 bool Host_HasWindowFocus()
 {
+    if (!g_hWnd) return false;
     HWND fore = GetForegroundWindow();
     return (g_hWnd == fore || g_hWnd == ::GetParent(fore));;
 }
@@ -232,6 +233,7 @@ void Host_ReleaseMouse()
 HostMouseState HostMouseImm_GetState()
 {
     HostMouseState result = {};
+    if (!g_hWnd) return result;
 
     POINT meh;
 

--- a/CraftEngine/ajek-gpu/src/msw/dx11-core_stuff.cpp
+++ b/CraftEngine/ajek-gpu/src/msw/dx11-core_stuff.cpp
@@ -479,15 +479,6 @@ void dx11_InitDevice()
 
     HRESULT hr = S_OK;
 
-    if (g_hWnd) {
-        RECT rc;
-        GetClientRect(g_hWnd, &rc);
-        g_client_size_pix = {
-            rc.right - rc.left,
-            rc.bottom - rc.top
-        };
-    }
-
     x_abort_on(g_client_size_pix.cmp_any() <= 0,
         "Invalid client size. Please create a window prior to dx11_InitDevice(). If not running in windowed mode then please "
         "initialize g_client_size_pix prior to dx11_InitDevice()."

--- a/CraftEngine/src/CliConfigOption.cpp
+++ b/CraftEngine/src/CliConfigOption.cpp
@@ -268,6 +268,12 @@ static const CliOptionDesc s_valid_options_list[] = {
         g_settings_hostwnd.has_client_size |= to_int2(g_settings_hostwnd.client_size, value);
     }},
 
+    { "backbuffer-size"             ,[](const xString& value){
+        g_settings_app.has_backbuffer_size |= to_int2(g_settings_app.backbuffer_size, value);
+    }},
+    { "windowless-mode"             ,[](const xString& value){ to_bool(g_settings_app.windowless_mode, value); }},
+    { "process-auto-kill"           ,[](const xString& value){ to_any_int(g_settings_app.kill_at_frame_number, value); }},
+
     { "audio-global-volume"         ,[](const xString& value){ to_float(g_settings_audio.glo_volume, value); }},
     { "audio-bgm-volume"            ,[](const xString& value){ to_float(g_settings_audio.bgm_volume, value); }},
     { "audio-sfx-volume"            ,[](const xString& value){ to_float(g_settings_audio.sfx_volume, value); }},

--- a/CraftEngine/src/appConfig.cpp
+++ b/CraftEngine/src/appConfig.cpp
@@ -10,7 +10,8 @@
 #include "ajek-script.h"
 
 
-HostwindowSettings g_settings_hostwnd;
+HostwindowSettings  g_settings_hostwnd;
+HostAppSettings     g_settings_app;
 
 
 void CliParseFromFile(const xString& srcfullpath)

--- a/CraftEngine/src/appConfig.h
+++ b/CraftEngine/src/appConfig.h
@@ -7,10 +7,18 @@
 //  - use HostwindowSettings().client_size to get the original defalut value.
 struct HostwindowSettings
 {
-    int2    client_pos      = {   64,   64 };
-    int2    client_size     = { 1280,  720 };
-    bool    has_client_pos  = false;
-    bool    has_client_size = false;
+    int2    client_pos              = {   64,   64 };
+    int2    client_size             = { 1280,  720 };
+    bool    has_client_pos          = false;
+    bool    has_client_size         = false;
+};
+
+struct HostAppSettings
+{
+    int2    backbuffer_size         = { 1280,  720 };
+    bool    has_backbuffer_size     = false;
+    bool    windowless_mode         = false;
+    int     kill_at_frame_number    = 0;
 };
 
 struct AudioSettings
@@ -44,6 +52,7 @@ struct AudioSettings
 };
 
 
+extern HostAppSettings      g_settings_app;
 extern HostwindowSettings   g_settings_hostwnd;
 extern AudioSettings        g_settings_audio;
 


### PR DESCRIPTION
Ref Issue #101 

Includes support for:
 - auto-killing process after some number of rendered frames.
 - backbuffer size specified independently of the window client size

CLI Options added:
```
   windowless-mode=bool
   backbuffer-size=int,int
   process-auto-kill=int
```