### PR TITLE
[static-analysis] Update printf attributes and fix reported problems

### DIFF
--- a/CraftEngine/ajek-framework/h/x-assertion.h
+++ b/CraftEngine/ajek-framework/h/x-assertion.h
@@ -212,13 +212,10 @@ struct AssertContextInfoTriad {
 };
 
 
-extern void     vlog_append_host_clock  (xString& dest);
-extern void     vlog_append_prefix      (xString& buffer, const char* moduleName);
-
-extern void     log_host           (const char* fmt = nullptr, ...)    __verify_fmt(3, 4);
-extern void     warn_host          (const char* fmt = nullptr, ...)    __verify_fmt(3, 4);
-extern void     log_host_v         (const char* fmt, va_list params);
-extern void     warn_host_v        (const char* fmt = nullptr, ...)    __verify_fmt(3, 4);
+extern void     log_host           (_Printf_format_string_ const char* fmt = nullptr, ...)    __verify_fmt(1, 2);
+extern void     warn_host          (_Printf_format_string_ const char* fmt = nullptr, ...)    __verify_fmt(1, 2);
+extern void     log_host_v         (_Printf_format_string_ const char* fmt, va_list params)   __verify_fmt(1, 0);
+extern void     warn_host_v        (_Printf_format_string_ const char* fmt, va_list params)   __verify_fmt(1, 0);
 
 extern void     xPrintLn            (const xString& msg);
 extern void     flush_log           ();
@@ -370,8 +367,6 @@ extern bool     xIsDebuggerAttached ();
 //  * Clicking "Ignore All" on an assertion while another thread is generating the very
 //    same assertion may not immediately take effect, since the assertion recursion check
 //    occurs after the Ignore-All check.  Not worth fixing, we assume...
-
-#define EXPAND( x ) x
 
 namespace
 {

--- a/CraftEngine/ajek-framework/h/x-stdfile.h
+++ b/CraftEngine/ajek-framework/h/x-stdfile.h
@@ -78,7 +78,7 @@ public:
     template< typename T >
     bool Read( T& dest )
     {
-        serialization_assert(T);
+        static_assert(xIs_trivially_copyable(T), "Cannot serialize non-POD object.");
         return Read( &dest, sizeof(T) );
     }
 };

--- a/CraftEngine/ajek-framework/h/x-stdlib.h
+++ b/CraftEngine/ajek-framework/h/x-stdlib.h
@@ -9,9 +9,6 @@
 #include <cstring>      // needed for memset
 #include <type_traits>
 
-#define serialization_assert(T) \
-    static_assert(xIs_trivially_copyable(T), "Cannot serialize non-POD object.")
-
 #if TARGET_LINUX
 #   define printf_s         printf
 #   define fprintf_s        fprintf

--- a/CraftEngine/ajek-framework/h/x-string.h
+++ b/CraftEngine/ajek-framework/h/x-string.h
@@ -165,16 +165,16 @@ public:
     xString&   RemoveAllMutable     (char c);
 // }
 
-    xString&   FormatV              (const char*    fmt, va_list list);
-    xString&   AppendFmtV           (const char*    fmt, va_list list);
-    xString&   Format               (const char*    fmt=nullptr, ...)     __verify_fmt(2,3);
-    xString&   AppendFmt            (const char*    fmt=nullptr, ...)     __verify_fmt(2,3);
+    xString&   FormatV              (_Printf_format_string_ const char*    fmt, va_list list);
+    xString&   AppendFmtV           (_Printf_format_string_ const char*    fmt, va_list list);
+    xString&   Format               (_Printf_format_string_ const char*    fmt=nullptr, ...)     __verify_fmt(2,3);
+    xString&   AppendFmt            (_Printf_format_string_ const char*    fmt=nullptr, ...)     __verify_fmt(2,3);
 
 #if TARGET_MSW
-    xString&   FormatV              (const wchar_t* fmt, va_list list);
-    xString&   AppendFmtV           (const wchar_t* fmt, va_list list);
-    xString&   Format               (const wchar_t* fmt, ...)     __verify_fmt(2,3);
-    xString&   AppendFmt            (const wchar_t* fmt, ...)     __verify_fmt(2,3);
+    xString&   FormatV              (_Printf_format_string_ const wchar_t* fmt, va_list list);
+    xString&   AppendFmtV           (_Printf_format_string_ const wchar_t* fmt, va_list list);
+    xString&   Format               (_Printf_format_string_ const wchar_t* fmt, ...)     __verify_fmt(2,3);
+    xString&   AppendFmt            (_Printf_format_string_ const wchar_t* fmt, ...)     __verify_fmt(2,3);
 #endif
 
     xString    ToLower              ()  const;
@@ -349,7 +349,6 @@ extern  xString     xPosixErrorStr      (int errorval);
 extern  xString     xPosixErrorStr      ();
 extern  bool        xStringToBoolean    (const xString& src);
 extern  bool        xStringIsBoolean    (const xString& src);
-
 
 // --------------------------------------------------------------------------------------
 //  xHexStr (template function)

--- a/CraftEngine/ajek-framework/h/x-types.h
+++ b/CraftEngine/ajek-framework/h/x-types.h
@@ -115,7 +115,7 @@ typedef void VoidFunc();
 #   include <kernel.h>
 #   include "../../thirdparty/gcc/intrin_x86.h"
 #elif defined(__GNUC__)
-// this includes all XMMs, which is really not what I want, but GCC isn't keen on letting us jsut include ia32intrin.h.  :(
+// this includes all XMMs, which is really not what I want, but GCC isn't keen on letting us just include ia32intrin.h.  :(
 #   include <x86intrin.h>
 #   include "intrin_x86.h"      // thirdparty provision, mimics microsoft/intel <intrin.h>
 #else
@@ -145,15 +145,11 @@ typedef void VoidFunc();
 
 #if defined(__clang__)
 
-#if !defined(SCE_ORBIS_SDK_VERSION)
-// Note: ORBIS SDK already defines several things that we've also be defining here (yay!)
-//       Such as __unused, __aligned(), __noinline, etc.
 #   define __aligned(x)             __attribute__((aligned(x)))
 #   define __noinline               __attribute__((noinline))
 #   define __unused                 __attribute__((unused))
 #   define __used
 #   define __packed                 __attribute__((packed))
-#endif
 
 #   define sealed                   final
 #   define __alwaysinline           __attribute__((always_inline))
@@ -170,10 +166,8 @@ typedef void VoidFunc();
 #   define __noreturn               __attribute__((noreturn))
 #   define __optimize(n)
 #   define _msc_pragma(str)
-#   if !defined(SCE_ORBIS_SDK_VERSION) || (SCE_ORBIS_SDK_VERSION >> 16) < 0x0200
-#       define  xIs_trivially_copyable(x)   (std::is_trivially_copyable<T>::value)
-#       define  xIs_standard_layout(x)      (std::is_standard_layout<T>::value)
-#   endif
+#   define  xIs_trivially_copyable(x)   (std::is_trivially_copyable<T>::value)
+#   define  xIs_standard_layout(x)      (std::is_standard_layout<T>::value)
 #   define __verify_fmt(fmtpos, vapos)
 
 #   define foreach( typeVar, srclist )  for( typeVar : srclist)
@@ -274,7 +268,7 @@ typedef void VoidFunc();
 #   define  xIs_trivially_copyable(x)      (true)
 #endif
 
-// MSVC has no printf format verification fanciness :(
+// Visual Studio defines _Printf_format_string_ instead of attribute(format) things.
 #   define __verify_fmt(fmtpos, vapos)
 
 #   define foreach( typeVar, srclist )  for each( typeVar in srclist )
@@ -288,6 +282,12 @@ typedef void VoidFunc();
     typedef s32         ssize_t;
 #endif
 
+#endif
+
+#if !defined(_MSC_VER)
+// gcc uses __attribute__((format(printf))), but msvc uses _Printf_format_string_.
+// they need to be placed at different locations though, so two macros are needed.
+#   define _Printf_format_string_
 #endif
 
 #define EXPECT_FALSE(a)             EXPECT((a), (false))

--- a/CraftEngine/ajek-framework/src/x-environ.cpp
+++ b/CraftEngine/ajek-framework/src/x-environ.cpp
@@ -43,17 +43,17 @@ xString xEnvironGet(const xString& varname)
     int err;
 
     err = getenv_s(&reqlen, NULL, 0, varname);
-    x_abort_on(err, "getenv_s(%s) failed with code %d(%s)", varname.c_str(), err, xPosixErrorStr(err));
+    x_abort_on(err, "getenv_s(%s) failed with code %d(%s)", varname.c_str(), err, cPosixErrorStr(err));
     if (!reqlen) { return xString(); }
 
     result.Resize(reqlen);
     err = getenv_s(&reqlen, result.data(), reqlen, varname);
-    x_abort_on(err, "getenv_s(%s) failed with code %d(%s)", varname.c_str(), err, xPosixErrorStr(err));
+    x_abort_on(err, "getenv_s(%s) failed with code %d(%s)", varname.c_str(), err, cPosixErrorStr(err));
     return result;
 }
 
 void xEnvironSet(const xString& varname, const xString& value, bool overwrite)
 {
     int err = setenv(varname, value, overwrite);
-    x_abort_on(err, "setenv(%s, %s) failed with code %d(%s)", varname.c_str(), value.c_str(), err, xPosixErrorStr(err));
+    x_abort_on(err, "setenv(%s, %s) failed with code %d(%s)", varname.c_str(), value.c_str(), err, cPosixErrorStr(err));
 }

--- a/CraftEngine/ajek-script/src/ajek-script.cpp
+++ b/CraftEngine/ajek-script/src/ajek-script.cpp
@@ -111,7 +111,7 @@ void AjekScript_SetDebugRelativePath(const xString& relpath)
 // luaL_error() is expected to be called from a C function (lualib), which means the parameter for "where" is 1,
 // when we actually need it to be zero when in the context fot he Lua VM itself.
 
-int luaVM_error (lua_State *L, const char *fmt, ...) {
+int luaVM_error (lua_State *L, _Printf_format_string_ const char *fmt, ...) __verify_fmt(2, 3) {
   va_list argp;
   va_start(argp, fmt);
   luaL_where(L, 0);

--- a/CraftEngine/ajekscript-interpreter/ajekscript-interpreter.cpp
+++ b/CraftEngine/ajekscript-interpreter/ajekscript-interpreter.cpp
@@ -60,7 +60,7 @@ assert_t xDebugBreak_v( DbgBreakType breakType, const AssertContextInfoTriad& tr
     return assert_break;
 }
 
-void log_host(const char* fmt, ...)
+void log_host(_Printf_format_string_ const char* fmt, ...)
 {
     if (fmt && fmt[0])
     {
@@ -72,7 +72,7 @@ void log_host(const char* fmt, ...)
     }
 }
 
-void log_host_v(const char* fmt, va_list list)
+void log_host_v(_Printf_format_string_ const char* fmt, va_list list)
 {
     if (fmt && fmt[0])
     {

--- a/CraftEngine/src/CliConfigOption.cpp
+++ b/CraftEngine/src/CliConfigOption.cpp
@@ -29,7 +29,7 @@ struct CliParseState {
 
     std::function<xString()>  diag_filepos;       // filename and line, pre-formatted for diagnostic printout
 
-    void        log_problem(const char* fmt, ...);
+    void        log_problem(_Printf_format_string_ const char* fmt, ...) __verify_fmt(2, 3);
     bool        boundscheck_int(int input, int lower, int upper);
 };
 
@@ -81,7 +81,7 @@ bool CliParseState::boundscheck_int(int input, int lower, int upper)
     return false;
 }
 
-void CliParseState::log_problem(const char* fmt, ...)
+void CliParseState::log_problem(_Printf_format_string_ const char* fmt, ...)
 {
     va_list arglist;
     va_start(arglist,fmt);
@@ -118,7 +118,7 @@ bool _cli_strtoi64(s64& dest, const char* src, char** endpos=nullptr, int radix=
     errno = 0;
     auto result = strtoll(src, endpos, radix);
     if (errno) {
-        s_cli->log_problem("toInt64(src='%s') failed: %s", src, strerror(errno));
+        s_cli->log_problem("toInt64(src='%s') failed: %s", src, cPosixErrorStr());
         return false;
     }
     if (local_endpos && (local_endpos[0] == '.')) {
@@ -126,7 +126,7 @@ bool _cli_strtoi64(s64& dest, const char* src, char** endpos=nullptr, int radix=
         auto result_f = strtof(src, endpos);
         if (errno) {
             // as far as I know, this shouldn't really happen (?)
-            s_cli->log_problem("toInt64(src='%s') strtof failed: %s", src, strerror(errno));
+            s_cli->log_problem("toInt64(src='%s') strtof failed: %s", src, cPosixErrorStr());
         }
         elif (result != (s64)result_f) {
             s_cli->log_problem("toInt64(src='%s') floating point value will be truncated", src, result);

--- a/CraftEngine/src/CliConfigSave.cpp
+++ b/CraftEngine/src/CliConfigSave.cpp
@@ -6,7 +6,7 @@
 
 #include "appConfig.h"
 
-void CliSaveSettingFmt(xString& dest, const char* option_name, const char* fmt, ...)
+void CliSaveSettingFmt(xString& dest, const char* option_name, _Printf_format_string_ const char* fmt, ...)
 {
     if (!cli_bug_chk_option_exists(option_name)) {
         bug_qa("cli save-settings: no parse handler exists for option '%s'", option_name);

--- a/CraftEngine/src/Entity.cpp
+++ b/CraftEngine/src/Entity.cpp
@@ -279,7 +279,7 @@ void OrderedDrawList::Add(EntityGid_t entityGid, float zorder, EntityFn_Draw* dr
         _Add( { entityPtr, draw }, zorder );
     }
     else {
-        EntityLog("DrawList: ignoring nil entity, gid=0x%08x.");
+        EntityLog("DrawList: ignoring nil entity, gid=0x%08x.", entityGid.val);
     }
 }
 

--- a/CraftEngine/src/appConfig.h
+++ b/CraftEngine/src/appConfig.h
@@ -63,7 +63,7 @@ extern xString      FindAsset               (const xString& src);
 extern void         CliParseOption          (const xString& utf8);
 extern void         CliParseOptionRaw       (const xString& utf8, const std::function<xString()>& file_line_no, int startpos=0);
 extern void         CliParseFromFile        (const xString& srcfullpath);
-extern void         CliSaveSettingFmt       (xString& dest, const char* option_name, const char* fmt, ...);
+extern void         CliSaveSettingFmt       (xString& dest, const char* option_name, _Printf_format_string_ const char* fmt, ...) __verify_fmt(3, 4);
 
 extern xString      Host_GetFullPathName    (const xString& relpath);
 

--- a/CraftEngine/src/main.cpp
+++ b/CraftEngine/src/main.cpp
@@ -69,8 +69,8 @@ float2 get2dPoint(const float4& point3D, const int2& viewSize, const XMMATRIX& v
     float4 xf2 = xform / xform.w;
 
     // This assumes viewOffset is center of the screen, directx style.
-    float winX = int (roundf((( xform.x + 1 ) / 2.0) * viewSize.x ));
-    float winY = int (roundf((( 1 - xform.y ) / 2.0) * viewSize.y ));
+    float winX = int (roundf((( xform.x + 1 ) / 2.0f) * viewSize.x ));
+    float winY = int (roundf((( 1 - xform.y ) / 2.0f) * viewSize.y ));
 
     // More generic OGL friendly version but I need to determine exactly what viewOffset should be, and I'm lazy --jstine
     //float winX = ((xf2.x + 1.0) / 2.0) * viewSize.x; // + viewOffset

--- a/CraftEngine/src/msw-WinMain.cpp
+++ b/CraftEngine/src/msw-WinMain.cpp
@@ -758,7 +758,7 @@ void _hostImpl_ImGui_NewFrame()
         io.MouseDown[2] = mouseState.pressed.MBUTTON;
 
         // Set OS mouse position if requested last frame by io.WantMoveMouse flag (used when io.NavMovesTrue is enabled by user and using directional navigation)
-        if (io.WantMoveMouse)
+        if (io.WantMoveMouse && g_hWnd)
         {
             POINT pos = { (int)io.MousePos.x, (int)io.MousePos.y };
             ::ClientToScreen(g_hWnd, &pos);

--- a/CraftEngine/src/x-log_host.cpp
+++ b/CraftEngine/src/x-log_host.cpp
@@ -168,7 +168,7 @@ static void _host_log_v(FILE* std_fp, const char* fmt, va_list list)
     //spamAbortCheck(buffer.GetLength() + 10);
 }
 
-void log_host(const char* fmt, ...)
+void log_host(_Printf_format_string_ const char* fmt, ...)
 {
     va_list list;
     va_start(list, fmt);
@@ -176,12 +176,12 @@ void log_host(const char* fmt, ...)
     va_end(list);
 }
 
-void log_host_v(const char* fmt, va_list list)
+void log_host_v(_Printf_format_string_ const char* fmt, va_list list)
 {
     _host_log_v(stdout, fmt, list);
 }
 
-void warn_host(const char* fmt, ...)
+void warn_host(_Printf_format_string_ const char* fmt, ...)
 {
     va_list list;
     va_start(list, fmt);
@@ -189,7 +189,7 @@ void warn_host(const char* fmt, ...)
     va_end(list);
 }
 
-void warn_host_v(const char* fmt, va_list list)
+void warn_host_v(_Printf_format_string_ const char* fmt, va_list list)
 {
     _host_log_v(stderr, fmt, list);
 }


### PR DESCRIPTION
Proper analysis has only been done for ajek-framework on clang so far.

Visual Studio static analysis is still pretty dodgy.  It doesn't catch things like `std::string` being passed into a printf function, presumably because Visual C++ still auto-converts to `.c_str()` when passing those into any varadic. 