### PR TITLE
Fix starting position

### DIFF
--- a/unity/Assets/Scripts/Game/Entity/Entity.cs
+++ b/unity/Assets/Scripts/Game/Entity/Entity.cs
@@ -92,7 +92,7 @@ public class Entity : MonoBehaviourEx
     }
 
     // This is Unity destroy method.
-    // I would much prefer we alway control our life-span through our function that be "surprised" my object is now dead
+    // I would much prefer we always control our life-span through our function that be "surprised" my object is now dead
     // should be called after everything have been taken care of
     private void OnDestroy()
     {
@@ -106,22 +106,29 @@ public class Entity : MonoBehaviourEx
         EntityManager.Instance.Unregister(this);
     }
 
+    /// <summary>
+    /// Set the position of the Entity. Entity will go through normal collision code and may refuse to be set to this position
+    /// </summary>
+    /// <param name="newPosition">New position of entity</param>
     public void SetPosition(Vector3 newPosition)
     {
         transform.position = newPosition;
     }
 
+    /// <summary>
+    /// Teleport Entity to position newPosition. No collision and no events are triggered by this move.
+    /// </summary>
+    /// <param name="newPosition">New position of eneity</param>
+    public void TeleportToPosition(Vector3 newPosition)
+    {
+        transform.position = newPosition;
+        m_lastPosition = newPosition;
+    }
+
     public Vector3 LastPosition
     {
-        get
-        {
-            return m_lastPosition;
-        }
-
-        private set
-        {
-            m_lastPosition = value;
-        }
+        get => m_lastPosition;
+        private set => m_lastPosition = value;
     }
 
     [SerializeField]

--- a/unity/Assets/Scripts/Game/Entity/Entity.cs
+++ b/unity/Assets/Scripts/Game/Entity/Entity.cs
@@ -118,7 +118,7 @@ public class Entity : MonoBehaviourEx
     /// <summary>
     /// Teleport Entity to position newPosition. No collision and no events are triggered by this move.
     /// </summary>
-    /// <param name="newPosition">New position of eneity</param>
+    /// <param name="newPosition">New position of entity</param>
     public void TeleportToPosition(Vector3 newPosition)
     {
         transform.position = newPosition;

--- a/unity/Assets/Scripts/Game/Managers/GameManager.cs
+++ b/unity/Assets/Scripts/Game/Managers/GameManager.cs
@@ -65,6 +65,7 @@ public class GameManager : MonoSingleton<GameManager>
     public void Start()
     {
         MainPlayer = m_mainCharacter.GetComponent<Player>();
+        MainPlayer.TeleportToPosition(Vector3.zero);
         m_worldMap.Generate();
     }
 

--- a/unity/Assets/Scripts/Game/Map/BiomeManager.cs
+++ b/unity/Assets/Scripts/Game/Map/BiomeManager.cs
@@ -133,17 +133,17 @@ public class BiomeManager
         switch (biome)
         {
             case EBiome.Plain:
-                return ETile.Grass;
+                return ETile.Mountain;
             case EBiome.Ocean:
-                return ETile.Water;
+                return ETile.Mountain;
             case EBiome.Forest:
-                return ETile.Tree;
+                return ETile.Mountain;
             case EBiome.Desert:
-                return ETile.Desert;
+                return ETile.Mountain;
             case EBiome.Mountain:
                 return ETile.Mountain;
             default:
-                return ETile.Grass;
+                return ETile.Mountain;
         }
     }
 

--- a/unity/Assets/Scripts/Game/Map/BiomeManager.cs
+++ b/unity/Assets/Scripts/Game/Map/BiomeManager.cs
@@ -133,17 +133,17 @@ public class BiomeManager
         switch (biome)
         {
             case EBiome.Plain:
-                return ETile.Mountain;
+                return ETile.Grass;
             case EBiome.Ocean:
-                return ETile.Mountain;
+                return ETile.Water;
             case EBiome.Forest:
-                return ETile.Mountain;
+                return ETile.Tree;
             case EBiome.Desert:
-                return ETile.Mountain;
+                return ETile.Desert;
             case EBiome.Mountain:
                 return ETile.Mountain;
             default:
-                return ETile.Mountain;
+                return ETile.Grass;
         }
     }
 


### PR DESCRIPTION
- Entity instance is now set to origin (0,0,0)
- Entity instance is now teleported to origin (0,0,0) if it was not at the beginning. This will be useful for custom spawn points later on.

Tested by forcing all biomes to be mountains. :)
Fix #84 