### PR TITLE
Fix OnDestroy name clash

### DIFF
--- a/unity/Assets/Scripts/Engine/Collision/CollisionManager.cs
+++ b/unity/Assets/Scripts/Engine/Collision/CollisionManager.cs
@@ -52,7 +52,7 @@ public class CollisionManager : MonoSingleton<CollisionManager>
         new Vector2(1, -1),
     };
     
-    public void OnDestroy(Entity entity)
+    public void OnRequestDestroy(Entity entity)
     {
         RemoveFromChunk(entity, entity.LastPosition);
     }

--- a/unity/Assets/Scripts/Game/Entity/Enemy.cs
+++ b/unity/Assets/Scripts/Game/Entity/Enemy.cs
@@ -97,11 +97,4 @@ public class Enemy : Entity
         dynamicText.ParentToWorld(anchor);
         dynamicText.SimpleMovement(new Vector2(0f, 16f), 1f);
     }
-
-    protected override void OnEntityDestroy()
-    {
-
-
-        base.OnEntityDestroy();
-    }
 }

--- a/unity/Assets/Scripts/Game/Entity/Entity.cs
+++ b/unity/Assets/Scripts/Game/Entity/Entity.cs
@@ -66,10 +66,9 @@ public class Entity : MonoBehaviourEx
     {
         m_fsm?.Update();
 
-
         if (m_destroying)
         {
-            OnEntityDestroy();
+            OnRequestDestroy();
         }
     }
 
@@ -83,17 +82,9 @@ public class Entity : MonoBehaviourEx
         LastPosition = newPosition;
     }
 
-    // This is Unity destroy method.
-    // I would much prefer we always control our life-span through our function that be "surprised" my object is now dead
-    // should be called after everything have been taken care of
-    private void OnDestroy()
+    protected virtual void OnRequestDestroy()
     {
-        //
-    }
-
-    protected virtual void OnEntityDestroy()
-    {
-        CollisionManager.Instance.OnDestroy(this);
+        CollisionManager.Instance.OnRequestDestroy(this);
         Destroy(gameObject);
         EntityManager.Instance.Unregister(this);
     }

--- a/unity/Assets/Scripts/Game/Entity/ItemInstance.cs
+++ b/unity/Assets/Scripts/Game/Entity/ItemInstance.cs
@@ -54,10 +54,10 @@ public class ItemInstance : Entity
 
     // http://docs.unity3d.com/ScriptReference/MonoBehaviour.OnDestroy.html
     // OnDestroy will only be called on game objects that have previously been active
-    protected override void OnEntityDestroy()
+    protected override void OnRequestDestroy()
     {
         ItemManager.Instance.Unregister(this);
 
-        base.OnEntityDestroy();
+        base.OnRequestDestroy();
     }
 }

--- a/unity/Assets/Scripts/Game/Entity/Slime.cs
+++ b/unity/Assets/Scripts/Game/Entity/Slime.cs
@@ -89,14 +89,6 @@ public class Slime : Enemy
         }
     }
 
-    // TODO: We will want a some point to distinguish when an Entity is killed a "gameplay" event
-    // and when an Entity is destroyed. When it is killed, we want to give rewards.
-    // when it is destroyed, we may not want to, since there could be other reasons (level ended, some cutscene removed all enemies, etc.)
-    protected override void OnEntityDestroy()
-    {
-        base.OnEntityDestroy();
-    }
-
     protected override void OnUpdate()
     {
         base.OnUpdate();

--- a/unity/Assets/Scripts/Game/Managers/EntityManager.cs
+++ b/unity/Assets/Scripts/Game/Managers/EntityManager.cs
@@ -45,8 +45,6 @@ public class EntityManager : MonoSingleton<EntityManager>
 
         if (entity_ is Player)
             UnregisterPlayer(entity_ as Player);
-
-        //OnDestroy.Invoke(entity_);
     }
 
     public Player Player


### PR DESCRIPTION
`OnDestroy` is a reserved Unity method https://docs.unity3d.com/ScriptReference/MonoBehaviour.OnDestroy.html
Use a different method name for requesting destruction of `Entity` instead.